### PR TITLE
docs: Add command for analyzing custom lints in a Flutter project

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ $ dart run custom_lint
   lib/main.dart:0:0 • This is the description of our custom lint • my_custom_lint_code
 ```
 
+If you are working on a Flutter project, run `flutter pub run custom_lint` instead.
+
 ---
 
 <p align="center">


### PR DESCRIPTION
Running `dart run custom_lint` in a Flutter project gives me the following error:

```
The Flutter SDK is not available.
#0      SdkSource.doGetDirectory (package:pub/src/source/sdk.dart:121:7)
#1      SystemCache.getDirectory (package:pub/src/system_cache.dart:208:22)
#2      SystemCache.load (package:pub/src/system_cache.dart:105:34)
#3      Entrypoint._assertLockFileUpToDate (package:pub/src/entrypoint.dart:624:19)
#4      Entrypoint.assertUpToDate (package:pub/src/entrypoint.dart:549:7)
#5      getExecutableForCommand (package:pub/src/executable.dart:304:16)
#6      RunCommand.run (package:dartdev/src/commands/run.dart:250:32)
#7      CommandRunner.runCommand (package:args/command_runner.dart:209:27)
#8      DartdevRunner.runCommand (package:dartdev/dartdev.dart:231:30)
#9      CommandRunner.run.<anonymous closure> (package:args/command_runner.dart:119:25)
#10     new Future.sync (dart:async/future.dart:301:31)
#11     CommandRunner.run (package:args/command_runner.dart:119:14)
#12     runDartdev (package:dartdev/dartdev.dart:66:29)
#13     main (file:///opt/s/w/ir/cache/builder/sdk/pkg/dartdev/bin/dartdev.dart:11:9)
#14     _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:293:32)
#15     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
```

The correct command to use in a Flutter project which doesn't result in errors is `flutter pub run custom_lint`. I've updated the docs accordingly.