### PR TITLE
fix non-working exit code

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased fix]
 
-- Fix custom_lint plugins not working in release mode and when using git dependencies
+- Fix custom_lint plugins not working in release mode and when using git dependencies (thanks to @TimWhiting)
+- Fix command line exit code not being set properly (thansk to @andrzejchm)
 
 ## 0.0.11
 

--- a/packages/custom_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/bin/custom_lint.dart
@@ -68,7 +68,7 @@ Future<int> main() async {
     stdout.writeln('No issues found!');
   }
 
-  return code;
+  exit(code);
 }
 
 extension on AnalysisErrorsParams {

--- a/packages/custom_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/bin/custom_lint.dart
@@ -7,8 +7,8 @@ import 'package:custom_lint/src/analyzer_plugin/plugin_delegate.dart';
 import 'package:custom_lint/src/runner.dart';
 import 'package:path/path.dart' as p;
 
-Future<int> main() async {
-  var code = 0;
+Future<void> main() async {
+  exitCode = 0;
 
   await runZonedGuarded(() async {
     final runner = CustomLintRunner(
@@ -20,8 +20,8 @@ Future<int> main() async {
     );
 
     runner.channel
-      ..responseErrors.listen((event) => code = -1)
-      ..pluginErrors.listen((event) => code = -1);
+      ..responseErrors.listen((event) => exitCode = -1)
+      ..pluginErrors.listen((event) => exitCode = -1);
 
     try {
       await runner.initialize();
@@ -48,7 +48,7 @@ Future<int> main() async {
         });
 
         for (final lint in lintsForFile.errors) {
-          code = -1;
+          exitCode = -1;
           stdout.writeln(
             '  $relativeFilePath:${lint.location.startLine}:${lint.location.startColumn}'
             ' • ${lint.message} • ${lint.code}',
@@ -59,16 +59,14 @@ Future<int> main() async {
       await runner.close();
     }
   }, (err, stack) {
-    code = -1;
+    exitCode = -1;
     stderr.writeln('$err\n$stack');
   });
 
   // Since no problem happened, we print a message saying everything went well
-  if (code == 0) {
+  if (exitCode == 0) {
     stdout.writeln('No issues found!');
   }
-
-  exit(code);
 }
 
 extension on AnalysisErrorsParams {

--- a/packages/custom_lint/test/cli_test.dart
+++ b/packages/custom_lint/test/cli_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:test/test.dart';
 
 import '../bin/custom_lint.dart' as cli;
@@ -85,9 +87,9 @@ class _AnotherLint extends PluginBase {
 
     await runWithIOOverride(
       (out, err) async {
-        final code = await cli.main();
+        await cli.main();
 
-        expect(code, 0);
+        expect(exitCode, 0);
         expect(out.join(), completion('''
 No issues found!
 '''));
@@ -108,9 +110,9 @@ No issues found!
 
     await runWithIOOverride(
       (out, err) async {
-        final code = await cli.main();
+        await cli.main();
 
-        expect(code, -1);
+        expect(exitCode, -1);
         expect(err.join(), completion('''
 IsolateSpawnException: Unable to spawn isolate: ${plugin.path}/bin/custom_lint.dart:1:1: \x1B[31mError: Variables must be declared using the keywords 'const', 'final', 'var' or a type name.
 Try adding the name of the type of the variable or the keyword 'var'.\x1B[39;49m
@@ -139,9 +141,9 @@ invalid;
 
     await runWithIOOverride(
       (out, err) async {
-        final code = await cli.main();
+        await cli.main();
 
-        expect(code, -1);
+        expect(exitCode, -1);
         expect(out.join(), completion('''
   lib/another.dart:1:6 • Hello world • hello_world
   lib/another.dart:1:6 • Oy • oy
@@ -172,9 +174,9 @@ invalid;
 
     await runWithIOOverride(
       (out, err) async {
-        final code = await cli.main();
+        await cli.main();
 
-        expect(code, -1);
+        expect(exitCode, -1);
         expect(
           err.join(),
           completion(
@@ -242,9 +244,9 @@ class _HelloWorldLint extends PluginBase {
 
     await runWithIOOverride(
       (out, err) async {
-        final code = await cli.main();
+        await cli.main();
 
-        expect(code, -1);
+        expect(exitCode, -1);
         expect(
           out.join(),
           completion(
@@ -363,9 +365,9 @@ void main() {
 
     await runWithIOOverride(
       (out, err) async {
-        final code = await cli.main();
+        await cli.main();
 
-        expect(code, -1);
+        expect(exitCode, -1);
         expect(
           err.join(),
           completion(isEmpty),


### PR DESCRIPTION
This change makes sure that in case of non-zero exit code, it is properly propagated to the CLI.

Currently, no matter if there's an error or not, the `flutter pub run custom_lint` always exits with `0` exit code