### PR TITLE
Feature/get full pub.dev score

### DIFF
--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^4.0.0
-  analyzer_plugin: ^0.10.0
+  analyzer_plugin: ^0.11.1
   async: ^2.8.2
   cli_util: ^0.3.5
   collection: ^1.15.0

--- a/packages/custom_lint_builder/pubspec.yaml
+++ b/packages/custom_lint_builder/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   analyzer: ^4.0.0
-  analyzer_plugin: ^0.10.0
+  analyzer_plugin: ^0.11.1
   collection: ^1.16.0
   # Using tight constraints as custom_lint_builder communicate with each-other
   # using a specific contract


### PR DESCRIPTION
This PR updates the `analyzer_plugin` dependency, resulting in a full `pub.dev` score.