### PR TITLE
Add issue tracker link for pub.dev

### DIFF
--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -2,6 +2,7 @@ name: custom_lint
 version: 0.0.9+1
 description: Lint rules are a powerful way to improve the maintainability of a project. Custom Lint allows package authors and developers to easily write custom lint rules.
 repository: https://github.com/invertase/dart_custom_lint
+issue_tracker: https://github.com/invertase/dart_custom_lint/issues
 
 environment:
   sdk: '>=2.17.1 <3.0.0'


### PR DESCRIPTION
With this PR, the right section on `pub.dev` will show the `View/report issues` link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).