### PR TITLE
Fix ignoring proper files

### DIFF
--- a/packages/custom_lint/example/analysis_options.yaml
+++ b/packages/custom_lint/example/analysis_options.yaml
@@ -3,6 +3,8 @@ include: ../../../analysis_options.yaml
 analyzer:
   plugins:
     - custom_lint
+  exclude:
+    - "**/*.g.dart"
 
 linter:
   rules:

--- a/packages/custom_lint/example/lib/main.g.dart
+++ b/packages/custom_lint/example/lib/main.g.dart
@@ -1,0 +1,13 @@
+import 'package:riverpod/riverpod.dart';
+
+void main() {
+  print('hello world');
+}
+
+class Main {}
+
+ProviderBase<int> provider = Provider((ref) => 0);
+
+Provider<int> provider2 = Provider((ref) => 0);
+
+Object? foo = 42;


### PR DESCRIPTION
The ContextRoot class has a analyzedFiles() method that returns all files that are supposed to be analyzed taking into account the analysis_options.yaml file etc.
``` dart
/// Return the absolute, normalized paths of all of the files that are
/// contained in this context. These are all of the files that are included
/// directly or indirectly by one or more of the [includedPaths] and that are
/// not excluded by any of the [excludedPaths].
///
/// Note that the list is not filtered based on the file suffix, so non-Dart
/// files can be returned.
```

The implementation class for ContextRoot (ContextRootImpl) has an excludeGlobs getter that is not exposed publically, so unless we want to cast it to the implementation class we need to use this public api to get files to be analyzed.

This fixes:
#13 (ignores all files under .dart_tool, and I"m assuming under .fvm and other symlinks as well), but I'm not 100% sure about the fvm use case, but it is likely to be closer to the performance of a regular dart analyze.

Note that #31 should also increase the speed of things.

Ready for review
@rrousselGit 

