### PR TITLE
fix: Remove custom_lint_plugin_loading lint from `dart analyze` commands

### DIFF
--- a/packages/custom_lint/lib/src/analyzer_plugin/analyzer_plugin_starter.dart
+++ b/packages/custom_lint/lib/src/analyzer_plugin/analyzer_plugin_starter.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:isolate';
 
 import 'analyzer_plugin.dart';
@@ -14,7 +15,9 @@ void start(Iterable<String> _, SendPort sendPort) {
       final channel = ClientIsolateChannel(sendPort);
       server = CustomLintPlugin(
         delegate: AnalyzerPluginCustomLintDelegate(),
-        includeBuiltInLints: true,
+        // Disable "loading" lints custom_lint is spawned from a terminal command;
+        // such as when using `dart analyze`
+        includeBuiltInLints: !stdin.hasTerminal,
         // The necessary flags for hot-reload to work aren't set by analyzer_plugin
         watchMode: false,
       );


### PR DESCRIPTION
fixes #16