### PR TITLE
Bump analyzer/plugin to 5.0.0/011.0

### DIFF
--- a/packages/custom_lint/example/example_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/example/example_lint/bin/custom_lint.dart
@@ -8,7 +8,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 bool _isProvider(DartType type) {
   // TODO refactor to use TypeChecker
   // TODO is it safe?
-  final element = type.element2! as ClassElement;
+  final element = type.element! as ClassElement;
   final source = element.librarySource.uri;
 
   final isProviderBase = source.scheme == 'package' &&

--- a/packages/custom_lint/example/example_lint/pubspec.yaml
+++ b/packages/custom_lint/example/example_lint/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
-  analyzer: ^4.6.0
+  analyzer: ^5.0.0
   custom_lint_builder:
     path: ../../../custom_lint_builder
 

--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
   sdk: '>=2.17.1 <3.0.0'
 
 dependencies:
-  analyzer: ^4.6.0
-  analyzer_plugin: ^0.10.0
+  analyzer: ^5.0.0
+  analyzer_plugin: ^0.11.0
   args: ^2.3.1
   async: ^2.8.2
   ci: ^0.1.0

--- a/packages/custom_lint_builder/example/example_lint/bin/custom_lint.dart
+++ b/packages/custom_lint_builder/example/example_lint/bin/custom_lint.dart
@@ -8,7 +8,7 @@ import 'package:custom_lint_builder/custom_lint_builder.dart';
 bool _isProvider(DartType type) {
   // TODO refactor to use TypeChecker
   // TODO is it safe?
-  final element = type.element2! as ClassElement;
+  final element = type.element! as ClassElement;
   final source = element.librarySource.uri;
 
   final isProviderBase = source.scheme == 'package' &&

--- a/packages/custom_lint_builder/example/example_lint/pubspec.yaml
+++ b/packages/custom_lint_builder/example/example_lint/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: '>=2.16.0 <3.0.0'
 
 dependencies:
-  analyzer: ^4.6.0
+  analyzer: ^5.0.0
   custom_lint_builder:
     path: ../../../custom_lint_builder
 

--- a/packages/custom_lint_builder/pubspec.yaml
+++ b/packages/custom_lint_builder/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: '>=2.17.1 <3.0.0'
 
 dependencies:
-  analyzer: ^4.6.0
-  analyzer_plugin: ^0.10.0
+  analyzer: ^5.0.0
+  analyzer_plugin: ^0.11.0
   collection: ^1.16.0
   # Using tight constraints as custom_lint_builder communicate with each-other
   # using a specific contract

--- a/packages/custom_lint_test/pubspec.yaml
+++ b/packages/custom_lint_test/pubspec.yaml
@@ -6,4 +6,4 @@ environment:
   sdk: ">=2.16.0 <3.0.0"
 
 dependencies:
-  analyzer: ^4.6.0
+  analyzer: ^5.0.0


### PR DESCRIPTION
As far as I can tell, there are no breaking changes in the packages themselves so it might be possible to specify a version range instead, like `>=4.6.0 <6.0.0`. Not sure if that makes sense.

Would be great if this can be packaged, a couple projects now waiting on custom_lint :)