### PR TITLE
Show all multiple context root errors on a single run

### DIFF
--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -92,13 +92,13 @@ class ConflictingPackagesChecker {
       final contextRoot = entry.key;
       final pubspec = _contextRootPubspecMap[contextRoot]!;
       final isFlutter = pubspec.dependencies.containsKey('flutter');
-      final flutterText = isFlutter ? 'flutter ' : '';
+      final command = isFlutter ? 'flutter' : 'dart';
 
       final conflictingPackages = entry.value;
       final conflictingPackagesNames =
           conflictingPackages.map((package) => package.name).join(' ');
       return 'cd ${contextRoot.root}\n'
-          '${flutterText}pub upgrade $conflictingPackagesNames';
+          '$command pub upgrade $conflictingPackagesNames';
     }).join('\n');
 
     throw StateError(

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -28,7 +28,7 @@ class ConflictingPackagesChecker {
   }
 
   /// Throws an error if there are conflicting packages.
-  void throwErrorIfMultiplePackageVersion() {
+  void throwErrorIfConflictingPackages() {
     final packageNameRootMap = <String, Set<Uri>>{};
     // Group packages by name and collect all unique roots,
     // since we're using a set
@@ -163,7 +163,7 @@ void _writePackageConfigForTempProject(
   }
 
   // Check if there are conflicting packages
-  conflictingPackagesChecker.throwErrorIfMultiplePackageVersion();
+  conflictingPackagesChecker.thowErrorIfConflictingPackages();
 
   targetFile.createSync(recursive: true);
 

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -163,7 +163,7 @@ void _writePackageConfigForTempProject(
   }
 
   // Check if there are conflicting packages
-  conflictingPackagesChecker.thowErrorIfConflictingPackages();
+  conflictingPackagesChecker.throwErrorIfConflictingPackages();
 
   targetFile.createSync(recursive: true);
 

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -81,7 +81,8 @@ class ConflictingPackagesChecker {
         }
         return '- ${package.name} $version\n';
       }).join();
-      final locationName = contextRoot.root.split('/').last;
+      final pubspec = _contextRootPubspecMap[contextRoot]!;
+      final locationName = pubspec.name;
       return '$locationName at ${contextRoot.root}\n'
           '$conflictingPackagesMessage'
           '\n';

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -54,10 +54,12 @@ class ConflictingPackagesChecker {
       // for each packageRoot, find the contextRoots that use it
       final packageRootsString = packageRoots.map((packageRoot) {
         final contextRoots = _contextRootPackagesMap.entries
-            .where((element) => element.value.any((package) => package.root == packageRoot))
+            .where((element) =>
+                element.value.any((package) => package.root == packageRoot))
             .map((e) => e.key)
             .toList();
-        final packageVersion = packageRoot.pathSegments[packageRoot.pathSegments.length - 2];
+        final packageVersion =
+            packageRoot.pathSegments[packageRoot.pathSegments.length - 2];
         return '    -- $packageVersion used in:\n'
             '${contextRoots.map((c) => '      --- ${c.root}\n').join()}';
       }).join();
@@ -76,7 +78,8 @@ class ConflictingPackagesChecker {
 }
 
 Future<int> _findPossiblyUnusedPort() {
-  return _SocketCustomLintServerToClientChannel._createServerSocket().then((value) => value.port);
+  return _SocketCustomLintServerToClientChannel._createServerSocket()
+      .then((value) => value.port);
 }
 
 Future<T> _asyncRetry<T>(
@@ -187,7 +190,8 @@ void _writePackageConfigForTempProject(
   );
 }
 
-class _SocketCustomLintServerToClientChannel implements CustomLintServerToClientChannel {
+class _SocketCustomLintServerToClientChannel
+    implements CustomLintServerToClientChannel {
   _SocketCustomLintServerToClientChannel(
     this._server,
     this._version,
@@ -253,14 +257,18 @@ class _SocketCustomLintServerToClientChannel implements CustomLintServerToClient
     final imports = _packages
         .map((e) => e.name)
         .map(
-          (packageName) => "import 'package:$packageName/$packageName.dart' as $packageName;\n",
+          (packageName) =>
+              "import 'package:$packageName/$packageName.dart' as $packageName;\n",
         )
         .join();
 
-    final plugins =
-        _packages.map((e) => e.name).map((packageName) => "'$packageName': $packageName.createPlugin,\n").join();
+    final plugins = _packages
+        .map((e) => e.name)
+        .map((packageName) => "'$packageName': $packageName.createPlugin,\n")
+        .join();
 
-    final mainFile = File(join(_tempDirectory.path, 'lib', 'custom_lint_client.dart'));
+    final mainFile =
+        File(join(_tempDirectory.path, 'lib', 'custom_lint_client.dart'));
     mainFile.createSync(recursive: true);
     mainFile.writeAsStringSync('''
 import 'dart:convert';
@@ -282,7 +290,8 @@ void main(List<String> args) async {
   }
 
   void _writePubspec() {
-    final dependencies = _packages.map((package) => '  ${package.name}: any').join();
+    final dependencies =
+        _packages.map((package) => '  ${package.name}: any').join();
 
     final pubspecFile = File(join(_tempDirectory.path, 'pubspec.yaml'));
     pubspecFile.createSync(recursive: true);
@@ -342,7 +351,9 @@ $dependencies
     }
 
     out.listen((event) => _server.handlePrint(event, isClientMessage: true));
-    process.stderr.map(utf8.decode).listen((e) => _server.handleUncaughtError(e, StackTrace.empty));
+    process.stderr
+        .map(utf8.decode)
+        .listen((e) => _server.handleUncaughtError(e, StackTrace.empty));
 
     // Checking process failure _after_ piping stdout/stderr to the log files.
     // This is so that if client failed to boot, logs in it should still be available
@@ -371,7 +382,9 @@ $dependencies
           );
 
           _server.analyzerPluginClientChannel.sendJson(
-            PluginErrorParams(true, 'Failed to start plugins', '').toNotification().toJson(),
+            PluginErrorParams(true, 'Failed to start plugins', '')
+                .toNotification()
+                .toJson(),
           );
 
           throw StateError('Failed to start the plugins.');

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -31,7 +31,8 @@ class _PackageAndContextRootPair {
 }
 
 Future<int> _findPossiblyUnusedPort() {
-  return _SocketCustomLintServerToClientChannel._createServerSocket().then((value) => value.port);
+  return _SocketCustomLintServerToClientChannel._createServerSocket()
+      .then((value) => value.port);
 }
 
 Future<T> _asyncRetry<T>(
@@ -136,8 +137,7 @@ void _writePackageConfigForTempProject(
   targetFile.createSync(recursive: true);
 
   final mappedPackageMap = {
-    for(final entry in packageMap.entries)
-      entry.key: entry.value.package,
+    for (final entry in packageMap.entries) entry.key: entry.value.package,
   };
 
   targetFile.writeAsStringSync(
@@ -163,7 +163,8 @@ void _writePackageConfigForTempProject(
   );
 }
 
-class _SocketCustomLintServerToClientChannel implements CustomLintServerToClientChannel {
+class _SocketCustomLintServerToClientChannel
+    implements CustomLintServerToClientChannel {
   _SocketCustomLintServerToClientChannel(
     this._server,
     this._version,
@@ -229,14 +230,18 @@ class _SocketCustomLintServerToClientChannel implements CustomLintServerToClient
     final imports = _packages
         .map((e) => e.name)
         .map(
-          (packageName) => "import 'package:$packageName/$packageName.dart' as $packageName;\n",
+          (packageName) =>
+              "import 'package:$packageName/$packageName.dart' as $packageName;\n",
         )
         .join();
 
-    final plugins =
-        _packages.map((e) => e.name).map((packageName) => "'$packageName': $packageName.createPlugin,\n").join();
+    final plugins = _packages
+        .map((e) => e.name)
+        .map((packageName) => "'$packageName': $packageName.createPlugin,\n")
+        .join();
 
-    final mainFile = File(join(_tempDirectory.path, 'lib', 'custom_lint_client.dart'));
+    final mainFile =
+        File(join(_tempDirectory.path, 'lib', 'custom_lint_client.dart'));
     mainFile.createSync(recursive: true);
     mainFile.writeAsStringSync('''
 import 'dart:convert';
@@ -258,7 +263,8 @@ void main(List<String> args) async {
   }
 
   void _writePubspec() {
-    final dependencies = _packages.map((package) => '  ${package.name}: any').join();
+    final dependencies =
+        _packages.map((package) => '  ${package.name}: any').join();
 
     final pubspecFile = File(join(_tempDirectory.path, 'pubspec.yaml'));
     pubspecFile.createSync(recursive: true);
@@ -318,7 +324,9 @@ $dependencies
     }
 
     out.listen((event) => _server.handlePrint(event, isClientMessage: true));
-    process.stderr.map(utf8.decode).listen((e) => _server.handleUncaughtError(e, StackTrace.empty));
+    process.stderr
+        .map(utf8.decode)
+        .listen((e) => _server.handleUncaughtError(e, StackTrace.empty));
 
     // Checking process failure _after_ piping stdout/stderr to the log files.
     // This is so that if client failed to boot, logs in it should still be available
@@ -347,7 +355,9 @@ $dependencies
           );
 
           _server.analyzerPluginClientChannel.sendJson(
-            PluginErrorParams(true, 'Failed to start plugins', '').toNotification().toJson(),
+            PluginErrorParams(true, 'Failed to start plugins', '')
+                .toNotification()
+                .toJson(),
           );
 
           throw StateError('Failed to start the plugins.');

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -65,13 +65,18 @@ extension on Package {
       // the version from the path, which is not ideal, but better than nothing
       return 'from git $version';
     }
-    final dependencyPath = dependency.path;
-    final dependencyPathString =
-        dependencyPath == null ? '' : ' path ${dependency.path}';
+    final versionBuilder = StringBuffer();
+    versionBuilder.write('from git url ${dependency.url}');
     final dependencyRef = dependency.ref;
-    final dependencyRefString =
-        dependencyRef == null ? '' : ' ref ${dependency.ref}';
-    return 'from git url ${dependency.url}$dependencyRefString$dependencyPathString';
+    if (dependencyRef != null) {
+      versionBuilder.write(' ref $dependencyRef');
+    }
+    final dependencyPath = dependency.path;
+    if (dependencyPath != null) {
+      versionBuilder.write(' path $dependencyPath');
+    }
+
+    return versionBuilder.toString();
   }
 }
 

--- a/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
+++ b/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
@@ -1,0 +1,109 @@
+import 'package:analyzer_plugin/protocol/protocol_generated.dart';
+import 'package:custom_lint/src/v2/server_to_client_channel.dart';
+import 'package:package_config/package_config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  Package createPackage(String name, String version) {
+    return Package(
+      name,
+      Uri.parse('file:///Users/user/.pub-cache/hosted/pub.dev/$name-$version/'),
+    );
+  }
+
+  ContextRoot createContextRoot(String relativePath) {
+    return ContextRoot('/Users/user/project/$relativePath', []);
+  }
+
+  group('ConflictingPackagesChecker', () {
+    test('should NOT throw error when there are no conflicting packages', () {
+      final checker = ConflictingPackagesChecker();
+      final contextRoots = [
+        createContextRoot('app'),
+        createContextRoot('app/packages/http'),
+      ];
+      final firstContextRootPackages = [
+        createPackage('riverpod', '2.2.0'),
+        createPackage('flutter_hooks', '0.18.6'),
+        createPackage('freezed', '2.3.2'),
+      ];
+      final secondContextRootPackages = [
+        // Same package as in the first context root
+        // so there is no conflict here
+        createPackage('riverpod', '2.2.0'),
+        createPackage('http', '0.13.3'),
+        createPackage('http_parser', '4.0.0'),
+      ];
+
+      checker.addContextRoot(contextRoots[0], firstContextRootPackages);
+      checker.addContextRoot(contextRoots[1], secondContextRootPackages);
+
+      expect(
+        checker.throwErrorIfMultiplePackageVersion,
+        returnsNormally,
+      );
+    });
+
+    test('should throw error when there are conflicting packages', () {
+      final checker = ConflictingPackagesChecker();
+      final contextRoots = [
+        createContextRoot('app'),
+        createContextRoot('app/packages/http'),
+        createContextRoot('app/packages/design_system'),
+      ];
+      final firstContextRootPackages = [
+        createPackage('riverpod', '2.2.0'),
+        createPackage('flutter_hooks', '0.18.6'),
+        createPackage('freezed', '2.3.2'),
+      ];
+      final secondContextRootPackages = [
+        // Same package as in the first context root, but with different version
+        // this should cause an error
+        createPackage('riverpod', '2.1.0'),
+        // This should also be shown in the error message
+        createPackage('flutter_hooks', '0.18.5'),
+        createPackage('http', '0.13.3'),
+        createPackage('http_parser', '4.0.0'),
+      ];
+      // Here we want to test that the error message contains multiple locations
+      final thirdContextRootPackages = [
+        createPackage('riverpod', '2.1.1'),
+        createPackage('flutter_hooks', '0.18.5'),
+      ];
+
+      checker.addContextRoot(contextRoots[0], firstContextRootPackages);
+      checker.addContextRoot(contextRoots[1], secondContextRootPackages);
+      checker.addContextRoot(contextRoots[2], thirdContextRootPackages);
+
+      expect(
+        checker.throwErrorIfMultiplePackageVersion,
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            equals(
+              'Some packages have conflicting versions:\n'
+              '- riverpod\n'
+              '    -- riverpod-2.2.0 used in:\n'
+              '      --- /Users/user/project/app\n'
+              '    -- riverpod-2.1.0 used in:\n'
+              '      --- /Users/user/project/app/packages/http\n'
+              '    -- riverpod-2.1.1 used in:\n'
+              '      --- /Users/user/project/app/packages/design_system\n'
+              '\n'
+              '- flutter_hooks\n'
+              '    -- flutter_hooks-0.18.6 used in:\n'
+              '      --- /Users/user/project/app\n'
+              '    -- flutter_hooks-0.18.5 used in:\n'
+              '      --- /Users/user/project/app/packages/http\n'
+              '      --- /Users/user/project/app/packages/design_system\n'
+              '\n'
+              'This is not supported. Please make sure all packages have the same version.\n'
+              'You could try running `flutter pub upgrade` in the affected directories.',
+            ),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
+++ b/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
@@ -246,9 +246,9 @@ void main() {
               'You could run the following commands to try fixing this:\n'
               '\n'
               'cd /Users/user/project/app\n'
-              'pub upgrade riverpod freezed\n' // <--- here
+              'dart pub upgrade riverpod freezed\n' // <--- here
               'cd /Users/user/project/app/packages/http\n'
-              'pub upgrade riverpod freezed', // <--- here
+              'dart pub upgrade riverpod freezed', // <--- here
             ),
           ),
         ),
@@ -314,9 +314,9 @@ void main() {
               'You could run the following commands to try fixing this:\n'
               '\n'
               'cd /Users/user/project/app\n'
-              'pub upgrade riverpod freezed\n'
+              'dart pub upgrade riverpod freezed\n'
               'cd /Users/user/project/app/packages/http\n'
-              'pub upgrade riverpod freezed',
+              'dart pub upgrade riverpod freezed',
             ),
           ),
         ),
@@ -383,9 +383,9 @@ void main() {
               'You could run the following commands to try fixing this:\n'
               '\n'
               'cd /Users/user/project/app\n'
-              'pub upgrade riverpod freezed\n'
+              'dart pub upgrade riverpod freezed\n'
               'cd /Users/user/project/app/packages/http\n'
-              'pub upgrade riverpod freezed',
+              'dart pub upgrade riverpod freezed',
             ),
           ),
         ),
@@ -452,9 +452,9 @@ void main() {
               'You could run the following commands to try fixing this:\n'
               '\n'
               'cd /Users/user/project/app\n'
-              'pub upgrade riverpod freezed\n'
+              'dart pub upgrade riverpod freezed\n'
               'cd /Users/user/project/app/packages/http\n'
-              'pub upgrade riverpod freezed',
+              'dart pub upgrade riverpod freezed',
             ),
           ),
         ),
@@ -520,9 +520,9 @@ void main() {
               'You could run the following commands to try fixing this:\n'
               '\n'
               'cd /Users/user/project/app\n'
-              'pub upgrade riverpod freezed\n'
+              'dart pub upgrade riverpod freezed\n'
               'cd /Users/user/project/app/packages/http\n'
-              'pub upgrade riverpod freezed',
+              'dart pub upgrade riverpod freezed',
             ),
           ),
         ),

--- a/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
+++ b/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
@@ -39,7 +39,7 @@ void main() {
       checker.addContextRoot(contextRoots[1], secondContextRootPackages);
 
       expect(
-        checker.throwErrorIfMultiplePackageVersion,
+        checker.throwErrorIfConflictingPackages,
         returnsNormally,
       );
     });
@@ -76,7 +76,7 @@ void main() {
       checker.addContextRoot(contextRoots[2], thirdContextRootPackages);
 
       expect(
-        checker.throwErrorIfMultiplePackageVersion,
+        checker.throwErrorIfConflictingPackages,
         throwsA(
           isA<StateError>().having(
             (error) => error.message,

--- a/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
+++ b/packages/custom_lint/test/src/v2/server_to_client_channel_test.dart
@@ -154,40 +154,37 @@ void main() {
             (error) => error.message,
             'message',
             equals(
-              'Some dependencies with conflicting versions were identified:\n'
-              '\n'
-              'app at /Users/user/project/app\n'
-              '- riverpod v2.2.0\n'
-              '- flutter_hooks v0.18.6\n'
-              '- freezed v2.3.2\n'
-              '\n'
-              'http at /Users/user/project/app/packages/http\n'
-              '- riverpod v2.1.0\n'
-              '- flutter_hooks v0.18.5\n'
-              '- http_parser v4.0.0\n'
-              '- freezed from path /Users/user/freezed/packages/freezed/\n'
-              '- http_parser from git 4cdfbf9159123746fce29d2862f148f901da66a/\n'
-              '\n'
-              'design_system at /Users/user/project/app/packages/design_system\n'
-              '- riverpod v2.1.1\n'
-              '- flutter_hooks v0.18.5\n'
-              '- freezed from git url ssh://git@github.com/rrousselGit/freezed.git ref 4cdfbf9159f2e9746fce29d2862f148f901da66a path packages/freezed\n'
-              '- http_parser v4.0.0\n'
-              '\n'
-              'This is not supported. Custom_lint shares the analysis between all'
-              ' packages. As such, all plugins are started under a single process,'
-              ' sharing the dependencies of all the packages that use custom_lint. '
-              "Since there's a single process for all plugins, if 2 plugins try to"
-              ' use different versions for a dependency, the process cannot be '
-              'reasonably started. Please make sure all packages have the same version.\n'
-              'You could run the following commands to try fixing this:\n'
-              '\n'
-              'cd /Users/user/project/app\n'
-              'flutter pub upgrade riverpod flutter_hooks freezed\n'
-              'cd /Users/user/project/app/packages/http\n'
-              'flutter pub upgrade riverpod flutter_hooks http_parser freezed http_parser\n'
-              'cd /Users/user/project/app/packages/design_system\n'
-              'flutter pub upgrade riverpod flutter_hooks freezed http_parser',
+              '''
+Some dependencies with conflicting versions were identified:
+
+app at /Users/user/project/app
+- riverpod v2.2.0
+- flutter_hooks v0.18.6
+- freezed v2.3.2
+
+http at /Users/user/project/app/packages/http
+- riverpod v2.1.0
+- flutter_hooks v0.18.5
+- http_parser v4.0.0
+- freezed from path /Users/user/freezed/packages/freezed/
+- http_parser from git 4cdfbf9159123746fce29d2862f148f901da66a/
+
+design_system at /Users/user/project/app/packages/design_system
+- riverpod v2.1.1
+- flutter_hooks v0.18.5
+- freezed from git url ssh://git@github.com/rrousselGit/freezed.git ref 4cdfbf9159f2e9746fce29d2862f148f901da66a path packages/freezed
+- http_parser v4.0.0
+
+This is not supported. Custom_lint shares the analysis between all packages. As such, all plugins are started under a single process, sharing the dependencies of all the packages that use custom_lint. Since there's a single process for all plugins, if 2 plugins try to use different versions for a dependency, the process cannot be reasonably started. Please make sure all packages have the same version.
+You could run the following commands to try fixing this:
+
+cd /Users/user/project/app
+flutter pub upgrade riverpod flutter_hooks freezed
+cd /Users/user/project/app/packages/http
+flutter pub upgrade riverpod flutter_hooks http_parser freezed http_parser
+cd /Users/user/project/app/packages/design_system
+flutter pub upgrade riverpod flutter_hooks freezed http_parser
+''',
             ),
           ),
         ),
@@ -227,28 +224,25 @@ void main() {
             (error) => error.message,
             'message',
             equals(
-              'Some dependencies with conflicting versions were identified:\n'
-              '\n'
-              'app at /Users/user/project/app\n'
-              '- riverpod v2.2.0\n'
-              '- freezed v2.3.2\n'
-              '\n'
-              'http at /Users/user/project/app/packages/http\n'
-              '- riverpod v2.1.0\n'
-              '- freezed v2.3.1\n'
-              '\n'
-              'This is not supported. Custom_lint shares the analysis between all'
-              ' packages. As such, all plugins are started under a single process,'
-              ' sharing the dependencies of all the packages that use custom_lint. '
-              "Since there's a single process for all plugins, if 2 plugins try to"
-              ' use different versions for a dependency, the process cannot be '
-              'reasonably started. Please make sure all packages have the same version.\n'
-              'You could run the following commands to try fixing this:\n'
-              '\n'
-              'cd /Users/user/project/app\n'
-              'dart pub upgrade riverpod freezed\n' // <--- here
-              'cd /Users/user/project/app/packages/http\n'
-              'dart pub upgrade riverpod freezed', // <--- here
+              '''
+Some dependencies with conflicting versions were identified:
+
+app at /Users/user/project/app
+- riverpod v2.2.0
+- freezed v2.3.2
+
+http at /Users/user/project/app/packages/http
+- riverpod v2.1.0
+- freezed v2.3.1
+
+This is not supported. Custom_lint shares the analysis between all packages. As such, all plugins are started under a single process, sharing the dependencies of all the packages that use custom_lint. Since there's a single process for all plugins, if 2 plugins try to use different versions for a dependency, the process cannot be reasonably started. Please make sure all packages have the same version.
+You could run the following commands to try fixing this:
+
+cd /Users/user/project/app
+dart pub upgrade riverpod freezed
+cd /Users/user/project/app/packages/http
+dart pub upgrade riverpod freezed
+''',
             ),
           ),
         ),
@@ -295,28 +289,25 @@ void main() {
             (error) => error.message,
             'message',
             equals(
-              'Some dependencies with conflicting versions were identified:\n'
-              '\n'
-              'app at /Users/user/project/app\n'
-              '- riverpod v2.2.0\n'
-              '- freezed v2.3.2\n'
-              '\n'
-              'http at /Users/user/project/app/packages/http\n'
-              '- riverpod v2.1.0\n'
-              '- freezed from git url ssh://git@github.com/rrousselGit/freezed.git\n'
-              '\n'
-              'This is not supported. Custom_lint shares the analysis between all'
-              ' packages. As such, all plugins are started under a single process,'
-              ' sharing the dependencies of all the packages that use custom_lint. '
-              "Since there's a single process for all plugins, if 2 plugins try to"
-              ' use different versions for a dependency, the process cannot be '
-              'reasonably started. Please make sure all packages have the same version.\n'
-              'You could run the following commands to try fixing this:\n'
-              '\n'
-              'cd /Users/user/project/app\n'
-              'dart pub upgrade riverpod freezed\n'
-              'cd /Users/user/project/app/packages/http\n'
-              'dart pub upgrade riverpod freezed',
+              '''
+Some dependencies with conflicting versions were identified:
+
+app at /Users/user/project/app
+- riverpod v2.2.0
+- freezed v2.3.2
+
+http at /Users/user/project/app/packages/http
+- riverpod v2.1.0
+- freezed from git url ssh://git@github.com/rrousselGit/freezed.git
+
+This is not supported. Custom_lint shares the analysis between all packages. As such, all plugins are started under a single process, sharing the dependencies of all the packages that use custom_lint. Since there's a single process for all plugins, if 2 plugins try to use different versions for a dependency, the process cannot be reasonably started. Please make sure all packages have the same version.
+You could run the following commands to try fixing this:
+
+cd /Users/user/project/app
+dart pub upgrade riverpod freezed
+cd /Users/user/project/app/packages/http
+dart pub upgrade riverpod freezed
+''',
             ),
           ),
         ),
@@ -364,28 +355,25 @@ void main() {
             (error) => error.message,
             'message',
             equals(
-              'Some dependencies with conflicting versions were identified:\n'
-              '\n'
-              'app at /Users/user/project/app\n'
-              '- riverpod v2.2.0\n'
-              '- freezed v2.3.2\n'
-              '\n'
-              'http at /Users/user/project/app/packages/http\n'
-              '- riverpod v2.1.0\n'
-              '- freezed from git url ssh://git@github.com/rrousselGit/freezed.git ref 4cdfbf9159f2e9746fce29d2862f148f901da66a\n'
-              '\n'
-              'This is not supported. Custom_lint shares the analysis between all'
-              ' packages. As such, all plugins are started under a single process,'
-              ' sharing the dependencies of all the packages that use custom_lint. '
-              "Since there's a single process for all plugins, if 2 plugins try to"
-              ' use different versions for a dependency, the process cannot be '
-              'reasonably started. Please make sure all packages have the same version.\n'
-              'You could run the following commands to try fixing this:\n'
-              '\n'
-              'cd /Users/user/project/app\n'
-              'dart pub upgrade riverpod freezed\n'
-              'cd /Users/user/project/app/packages/http\n'
-              'dart pub upgrade riverpod freezed',
+              '''
+Some dependencies with conflicting versions were identified:
+
+app at /Users/user/project/app
+- riverpod v2.2.0
+- freezed v2.3.2
+
+http at /Users/user/project/app/packages/http
+- riverpod v2.1.0
+- freezed from git url ssh://git@github.com/rrousselGit/freezed.git ref 4cdfbf9159f2e9746fce29d2862f148f901da66a
+
+This is not supported. Custom_lint shares the analysis between all packages. As such, all plugins are started under a single process, sharing the dependencies of all the packages that use custom_lint. Since there's a single process for all plugins, if 2 plugins try to use different versions for a dependency, the process cannot be reasonably started. Please make sure all packages have the same version.
+You could run the following commands to try fixing this:
+
+cd /Users/user/project/app
+dart pub upgrade riverpod freezed
+cd /Users/user/project/app/packages/http
+dart pub upgrade riverpod freezed
+''',
             ),
           ),
         ),
@@ -433,28 +421,25 @@ void main() {
             (error) => error.message,
             'message',
             equals(
-              'Some dependencies with conflicting versions were identified:\n'
-              '\n'
-              'app at /Users/user/project/app\n'
-              '- riverpod v2.2.0\n'
-              '- freezed v2.3.2\n'
-              '\n'
-              'http at /Users/user/project/app/packages/http\n'
-              '- riverpod v2.1.0\n'
-              '- freezed from git url ssh://git@github.com/rrousselGit/freezed.git path packages/freezed\n'
-              '\n'
-              'This is not supported. Custom_lint shares the analysis between all'
-              ' packages. As such, all plugins are started under a single process,'
-              ' sharing the dependencies of all the packages that use custom_lint. '
-              "Since there's a single process for all plugins, if 2 plugins try to"
-              ' use different versions for a dependency, the process cannot be '
-              'reasonably started. Please make sure all packages have the same version.\n'
-              'You could run the following commands to try fixing this:\n'
-              '\n'
-              'cd /Users/user/project/app\n'
-              'dart pub upgrade riverpod freezed\n'
-              'cd /Users/user/project/app/packages/http\n'
-              'dart pub upgrade riverpod freezed',
+              '''
+Some dependencies with conflicting versions were identified:
+
+app at /Users/user/project/app
+- riverpod v2.2.0
+- freezed v2.3.2
+
+http at /Users/user/project/app/packages/http
+- riverpod v2.1.0
+- freezed from git url ssh://git@github.com/rrousselGit/freezed.git path packages/freezed
+
+This is not supported. Custom_lint shares the analysis between all packages. As such, all plugins are started under a single process, sharing the dependencies of all the packages that use custom_lint. Since there's a single process for all plugins, if 2 plugins try to use different versions for a dependency, the process cannot be reasonably started. Please make sure all packages have the same version.
+You could run the following commands to try fixing this:
+
+cd /Users/user/project/app
+dart pub upgrade riverpod freezed
+cd /Users/user/project/app/packages/http
+dart pub upgrade riverpod freezed
+''',
             ),
           ),
         ),
@@ -501,28 +486,25 @@ void main() {
             (error) => error.message,
             'message',
             equals(
-              'Some dependencies with conflicting versions were identified:\n'
-              '\n'
-              'app at /Users/user/project/app\n'
-              '- riverpod v2.2.0\n'
-              '- freezed v2.3.2\n'
-              '\n'
-              'http at /Users/user/project/app/packages/http\n'
-              '- riverpod v2.1.0\n'
-              '- freezed from git url ssh://git@github.com/rrousselGit/freezed.git\n'
-              '\n'
-              'This is not supported. Custom_lint shares the analysis between all'
-              ' packages. As such, all plugins are started under a single process,'
-              ' sharing the dependencies of all the packages that use custom_lint. '
-              "Since there's a single process for all plugins, if 2 plugins try to"
-              ' use different versions for a dependency, the process cannot be '
-              'reasonably started. Please make sure all packages have the same version.\n'
-              'You could run the following commands to try fixing this:\n'
-              '\n'
-              'cd /Users/user/project/app\n'
-              'dart pub upgrade riverpod freezed\n'
-              'cd /Users/user/project/app/packages/http\n'
-              'dart pub upgrade riverpod freezed',
+              '''
+Some dependencies with conflicting versions were identified:
+
+app at /Users/user/project/app
+- riverpod v2.2.0
+- freezed v2.3.2
+
+http at /Users/user/project/app/packages/http
+- riverpod v2.1.0
+- freezed from git url ssh://git@github.com/rrousselGit/freezed.git
+
+This is not supported. Custom_lint shares the analysis between all packages. As such, all plugins are started under a single process, sharing the dependencies of all the packages that use custom_lint. Since there's a single process for all plugins, if 2 plugins try to use different versions for a dependency, the process cannot be reasonably started. Please make sure all packages have the same version.
+You could run the following commands to try fixing this:
+
+cd /Users/user/project/app
+dart pub upgrade riverpod freezed
+cd /Users/user/project/app/packages/http
+dart pub upgrade riverpod freezed
+''',
             ),
           ),
         ),


### PR DESCRIPTION
This change shows all the multiple context root erros on a single run, instead of showing one at a time.

It also improves the error message, listing the affected context root, printing its `pubspec.yaml` file path.

The new error message looks like:

```
The request analysis.setContextRoots failed with the following error:
RequestErrorCode.PLUGIN_ERROR
Bad state: The following packages are included in multiple ContextRoots:
- args
  -- ContextRoot: /Users/adson.leal/dev/sora/sora-world/sora_app
     file:///Users/adson.leal/.pub-cache/hosted/pub.dev/args-2.4.0/
  -- ContextRoot: /Users/adson.leal/dev/sora/sora-world/sora_app/packages/sora_http_generator
     file:///Users/adson.leal/.pub-cache/hosted/pub.dev/args-2.3.2/

- logging
  -- ContextRoot: /Users/adson.leal/dev/sora/sora-world/sora_app
     file:///Users/adson.leal/.pub-cache/hosted/pub.dev/logging-1.1.1/
  -- ContextRoot: /Users/adson.leal/dev/sora/sora-world/sora_app/packages/sora_http_generator
     file:///Users/adson.leal/.pub-cache/hosted/pub.dev/logging-1.1.0/

- go_router
  -- ContextRoot: /Users/adson.leal/dev/sora/sora-world/sora_app
     file:///Users/adson.leal/.pub-cache/hosted/pub.dev/go_router-6.0.9/
  -- ContextRoot: /Users/adson.leal/dev/sora/sora-world/sora_app/packages/home
     file:///Users/adson.leal/.pub-cache/hosted/pub.dev/go_router-6.2.0/
```

This PR is related to [this issue](https://github.com/invertase/dart_custom_lint/issues/89).