### PR TITLE
Refactor lint rendering to avoid loops

### DIFF
--- a/packages/custom_lint/lib/custom_lint.dart
+++ b/packages/custom_lint/lib/custom_lint.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer_plugin/protocol/protocol_generated.dart';
-import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 import 'src/plugin_delegate.dart';
@@ -89,24 +88,24 @@ void _renderLints(
   List<AnalysisErrorsParams> lints, {
   required Directory workingDirectory,
 }) {
-  final errors = lints
-      .expand(
-        (lintsForFile) => lintsForFile.errors
-          ..sort((a, b) {
-            final lineCompare =
-                a.location.startLine.compareTo(b.location.startLine);
-            if (lineCompare != 0) return lineCompare;
-            final columnCompare =
-                a.location.startColumn.compareTo(b.location.startColumn);
-            if (columnCompare != 0) return columnCompare;
+  final errors = lints.expand((lintsForFile) => lintsForFile.errors).toList()
+    ..sort((a, b) {
+      final fileCompare = _relativeFilePath(a.location.file, workingDirectory)
+          .compareTo(_relativeFilePath(b.location.file, workingDirectory));
+      if (fileCompare != 0) return fileCompare;
 
-            final codeCompare = a.code.compareTo(b.code);
-            if (codeCompare != 0) return codeCompare;
+      final lineCompare = a.location.startLine.compareTo(b.location.startLine);
+      if (lineCompare != 0) return lineCompare;
 
-            return a.message.compareTo(b.message);
-          }),
-      )
-      .sortedBy((e) => _relativeFilePath(e.location.file, workingDirectory));
+      final columnCompare =
+          a.location.startColumn.compareTo(b.location.startColumn);
+      if (columnCompare != 0) return columnCompare;
+
+      final codeCompare = a.code.compareTo(b.code);
+      if (codeCompare != 0) return codeCompare;
+
+      return a.message.compareTo(b.message);
+    });
 
   if (errors.isEmpty) {
     stdout.writeln('No issues found!');

--- a/packages/custom_lint/lib/custom_lint.dart
+++ b/packages/custom_lint/lib/custom_lint.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer_plugin/protocol/protocol_generated.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 import 'src/plugin_delegate.dart';
@@ -88,24 +89,26 @@ void _renderLints(
   List<AnalysisErrorsParams> lints, {
   required Directory workingDirectory,
 }) {
-  final errors = lints.expand((lintsForFile) => lintsForFile.errors).toList()
-    ..sort((a, b) {
-      final fileCompare = _relativeFilePath(a.location.file, workingDirectory)
-          .compareTo(_relativeFilePath(b.location.file, workingDirectory));
-      if (fileCompare != 0) return fileCompare;
+  var errors = lints.expand((lint) => lint.errors);
 
-      final lineCompare = a.location.startLine.compareTo(b.location.startLine);
-      if (lineCompare != 0) return lineCompare;
+  // Sort errors by file, line, column, code, message
+  errors = errors.sorted((a, b) {
+    final fileCompare = _relativeFilePath(a.location.file, workingDirectory)
+        .compareTo(_relativeFilePath(b.location.file, workingDirectory));
+    if (fileCompare != 0) return fileCompare;
 
-      final columnCompare =
-          a.location.startColumn.compareTo(b.location.startColumn);
-      if (columnCompare != 0) return columnCompare;
+    final lineCompare = a.location.startLine.compareTo(b.location.startLine);
+    if (lineCompare != 0) return lineCompare;
 
-      final codeCompare = a.code.compareTo(b.code);
-      if (codeCompare != 0) return codeCompare;
+    final columnCompare =
+        a.location.startColumn.compareTo(b.location.startColumn);
+    if (columnCompare != 0) return columnCompare;
 
-      return a.message.compareTo(b.message);
-    });
+    final codeCompare = a.code.compareTo(b.code);
+    if (codeCompare != 0) return codeCompare;
+
+    return a.message.compareTo(b.message);
+  });
 
   if (errors.isEmpty) {
     stdout.writeln('No issues found!');

--- a/packages/custom_lint/lib/custom_lint.dart
+++ b/packages/custom_lint/lib/custom_lint.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer_plugin/protocol/protocol_generated.dart';
+import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 import 'src/plugin_delegate.dart';
@@ -82,46 +83,42 @@ Future<void> _runPlugins(
     exitCode = 1;
     stderr.writeln('$err\n$stack');
   }
-
-  // Since no problem happened, we print a message saying everything went well
-  if (exitCode == 0) {
-    stdout.writeln('No issues found!');
-  }
 }
 
 void _renderLints(
   List<AnalysisErrorsParams> lints, {
   required Directory workingDirectory,
 }) {
-  lints.sort(
-    (a, b) => a
-        .relativeFilePath(workingDirectory)
-        .compareTo(b.relativeFilePath(workingDirectory)),
-  );
+  final errors = lints
+      .expand(
+        (lintsForFile) => lintsForFile.errors
+          ..sort((a, b) {
+            final lineCompare =
+                a.location.startLine.compareTo(b.location.startLine);
+            if (lineCompare != 0) return lineCompare;
+            final columnCompare =
+                a.location.startColumn.compareTo(b.location.startColumn);
+            if (columnCompare != 0) return columnCompare;
 
-  for (final lintsForFile in lints) {
-    final relativeFilePath = lintsForFile.relativeFilePath(workingDirectory);
+            final codeCompare = a.code.compareTo(b.code);
+            if (codeCompare != 0) return codeCompare;
 
-    lintsForFile.errors.sort((a, b) {
-      final lineCompare = a.location.startLine.compareTo(b.location.startLine);
-      if (lineCompare != 0) return lineCompare;
-      final columnCompare =
-          a.location.startColumn.compareTo(b.location.startColumn);
-      if (columnCompare != 0) return columnCompare;
+            return a.message.compareTo(b.message);
+          }),
+      )
+      .sortedBy((e) => _relativeFilePath(e.location.file, workingDirectory));
 
-      final codeCompare = a.code.compareTo(b.code);
-      if (codeCompare != 0) return codeCompare;
+  if (errors.isEmpty) {
+    stdout.writeln('No issues found!');
+    return;
+  }
 
-      return a.message.compareTo(b.message);
-    });
-
-    for (final lint in lintsForFile.errors) {
-      exitCode = 1;
-      stdout.writeln(
-        '  $relativeFilePath:${lint.location.startLine}:${lint.location.startColumn}'
-        ' • ${lint.message} • ${lint.code}',
-      );
-    }
+  exitCode = 1;
+  for (final error in errors) {
+    stdout.writeln(
+      '  ${_relativeFilePath(error.location.file, workingDirectory)}:${error.location.startLine}:${error.location.startColumn}'
+      ' • ${error.message} • ${error.code}',
+    );
   }
 }
 
@@ -154,11 +151,9 @@ Future<void> _startWatchMode(CustomLintRunner runner) async {
   }
 }
 
-extension on AnalysisErrorsParams {
-  String relativeFilePath(Directory dir) {
-    return p.relative(
-      file,
-      from: dir.path,
-    );
-  }
+String _relativeFilePath(String file, Directory fromDir) {
+  return p.relative(
+    file,
+    from: fromDir.absolute.path,
+  );
 }

--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -14,7 +14,6 @@ dependencies:
   async: ^2.8.2
   ci: ^0.1.0
   cli_util: ^0.3.5
-  collection: ^1.16.0
   freezed_annotation: ^2.2.0
   json_annotation: ^4.7.0
   meta: ^1.7.0

--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   async: ^2.8.2
   ci: ^0.1.0
   cli_util: ^0.3.5
+  collection: ^1.16.0
   freezed_annotation: ^2.2.0
   json_annotation: ^4.7.0
   meta: ^1.7.0


### PR DESCRIPTION
This makes future changes to the output easier and allows for easier chaining of more sort parameters (severity).

There are no changes in tests, the output stays the same with this change.