### PR TITLE
The command line no-longer throws if ran on an empty project or a project with no plugins enabled

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Upgraded `analyzer` to `>=5.7.0 <5.11.0`
 - `LintRuleNodeRegistry` and other AstVisitor-like now are based off `GeneralizingAstVisitor` instead of `GeneralizingAstVisitor`
 - Upgraded `cli_util` to `^0.4.0`
+- The command line no-longer throws if ran on an empty project or a project with
+  no plugins enabled
 
 ## 0.3.2 - 2023-03-09
 

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -44,7 +44,6 @@ class SocketCustomLintServerToClientChannel {
     this._socket,
     this._version,
     this._contextRoots,
-    this._workingDirectory,
     this._workspace,
   ) : _channel = JsonSocketChannel(_socket);
 
@@ -72,7 +71,7 @@ class SocketCustomLintServerToClientChannel {
       serverSocket.safeFirst,
       version,
       contextRoots,
-      workingDirectory, workspace,
+      workspace,
     );
   }
 
@@ -80,7 +79,6 @@ class SocketCustomLintServerToClientChannel {
 
   final Future<Socket> _socket;
   final JsonSocketChannel _channel;
-  final Directory _workingDirectory;
   final CustomLintServer _server;
   final PluginVersionCheckParams _version;
   final ServerSocket _serverSocket;

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -45,15 +45,24 @@ class SocketCustomLintServerToClientChannel {
     this._version,
     this._contextRoots,
     this._workingDirectory,
+    this._workspace,
   ) : _channel = JsonSocketChannel(_socket);
 
   /// Starts a server socket and exposes a way to communicate with potential clients.
-  static Future<SocketCustomLintServerToClientChannel> create(
+  ///
+  /// Returns `null` if the workspace has no plugins enabled.
+  static Future<SocketCustomLintServerToClientChannel?> create(
     CustomLintServer server,
     PluginVersionCheckParams version,
     AnalysisSetContextRootsParams contextRoots, {
     required Directory workingDirectory,
   }) async {
+    final workspace = await CustomLintWorkspace.fromContextRoots(
+      contextRoots.roots,
+      workingDirectory: workingDirectory,
+    );
+    if (workspace.uniquePluginNames.isEmpty) return null;
+
     final serverSocket = await _createServerSocket();
 
     return SocketCustomLintServerToClientChannel._(
@@ -63,7 +72,7 @@ class SocketCustomLintServerToClientChannel {
       serverSocket.safeFirst,
       version,
       contextRoots,
-      workingDirectory,
+      workingDirectory, workspace,
     );
   }
 
@@ -75,7 +84,8 @@ class SocketCustomLintServerToClientChannel {
   final CustomLintServer _server;
   final PluginVersionCheckParams _version;
   final ServerSocket _serverSocket;
-  late final Future<Process> _processFuture;
+  late final Future<Process?> _processFuture;
+  final CustomLintWorkspace _workspace;
 
   AnalysisSetContextRootsParams _contextRoots;
 
@@ -106,6 +116,8 @@ class SocketCustomLintServerToClientChannel {
   Future<void> init() async {
     _processFuture = _startProcess();
     final process = await _processFuture;
+    // No process started, likely because no plugin were detected. We can stop here.
+    if (process == null) return;
 
     var out = process.stdout.map(utf8.decode);
     // Let's not log the VM service prints unless in watch mode
@@ -147,15 +159,10 @@ class SocketCustomLintServerToClientChannel {
   /// without setting up the connection.
   ///
   /// Will throw if the process fails to start.
-  Future<Process> _startProcess() async {
-    final workspace = await CustomLintWorkspace.fromContextRoots(
-      _contextRoots.roots,
-      workingDirectory: _workingDirectory,
-    );
-
+  Future<Process?> _startProcess() async {
     final tempDirectory =
-        _tempDirectory = await workspace.createPluginHostDirectory();
-    _writeEntrypoint(workspace.uniquePluginNames, tempDirectory);
+        _tempDirectory = await _workspace.createPluginHostDirectory();
+    _writeEntrypoint(_workspace.uniquePluginNames, tempDirectory);
 
     return _asyncRetry(retryCount: 5, () async {
       // Using "late" to fetch the port only if needed (in watch mode)
@@ -288,7 +295,7 @@ void main(List<String> args) async {
       _serverSocket.close(),
       _channel.close(),
       _processFuture.then<void>(
-        (value) => value.kill(),
+        (value) => value?.kill(),
         // The process wasn't started. No need to do anything.
         onError: (_) {},
       )

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -26,7 +26,39 @@ void main() {
     'custom_lint.dart',
   );
 
-  group('Correctly exits with', () {
+  group('Correctly exits when', () {
+    test('running on a workspace with no plugins', () {
+      final app = createLintUsage(name: 'test_app');
+
+      final process = Process.runSync(
+        'dart',
+        [customLintBinPath],
+        workingDirectory: app.path,
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
+      );
+
+      expect(trimDependencyOverridesWarning(process.stderr), isEmpty);
+      expect(process.stdout, 'No issues found!\n');
+      expect(process.exitCode, 0);
+    });
+
+    test('running on a workspace with no projects', () {
+      final dir = createTemporaryDirectory();
+
+      final process = Process.runSync(
+        'dart',
+        [customLintBinPath],
+        workingDirectory: dir.path,
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
+      );
+
+      expect(trimDependencyOverridesWarning(process.stderr), isEmpty);
+      expect(process.stdout, 'No issues found!\n');
+      expect(process.exitCode, 0);
+    });
+
     test(
       'no issues found',
       () async {


### PR DESCRIPTION
fixes #77