### PR TITLE
Update JsonSocketChannel to send the message length in the uintlist instead of a trailing \n

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased fix
+
+- Update the socket communication logic to avoid possible problem is the message
+  contains a \n.
+
 ## 0.3.3 - 2023-04-06
 
 - Reduce the likelyness of a dependency version conflict.


### PR DESCRIPTION
This ensures that if the message contains a \n, the logic continues to work.