### PR TITLE
Resolve packages using "pub get" if local resolution fails

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Unreleased minor
 
+- Now resolves packages using `pub get` if custom_lint failed to resolve packages offline.
+  This should reduce the likelyness of a version conflict in mono-repositories.
+  The conflict may still happen if two projects in a mono-repo use incompatible
+  constraints. Like:
+  ```yaml
+  name: foo
+  dependencies:
+    package: ^1.0.0
+  ```
+  ```yaml
+  name: bar
+  dependencies:
+    package: ^2.0.0
+  ```
 - The command line now shows the lints' severity (thanks to @praxder)
 - Now requires Dart 3.0.0
 

--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased minor
 
 - The command line now shows the lints' severity (thanks to @praxder)
+- Now requires Dart 3.0.0
 
 ## 0.4.0 - 2023-05-12
 

--- a/packages/custom_lint/lib/src/package_utils.dart
+++ b/packages/custom_lint/lib/src/package_utils.dart
@@ -34,6 +34,9 @@ extension PackageIOUtils on Directory {
   /// The `pubspec.yaml` file.
   File get pubspec => file('pubspec.yaml');
 
+  /// The `pubspec_overrides.yaml` file.
+  File get pubspecOverrides => file('pubspec_overrides.yaml');
+
   /// The `.dart_tool/package_config.json` file.
   File get packageConfig => file('.dart_tool', 'package_config.json');
 
@@ -79,6 +82,37 @@ Future<Pubspec?> tryParsePubspec(Directory directory) async {
 /// does not exists.
 Future<Pubspec> parsePubspec(Directory directory) async {
   return Pubspec.parse(await directory.pubspec.readAsString());
+}
+
+/// Try parsing the `pubspec_overrides.yaml` of the given directory.
+///
+/// If the parsing fails for any reason, returns null.
+Future<Map<String, Dependency>?> tryParsePubspecOverrides(
+  Directory directory,
+) async {
+  try {
+    return await parsePubspecOverrides(directory);
+  } catch (_) {
+    return null;
+  }
+}
+
+/// Parse the `pubspec_overrides.yaml` of the given directory.
+///
+/// Throws if the parsing fails, such as if the file is badly formatted or
+/// does not exists.
+Future<Map<String, Dependency>> parsePubspecOverrides(
+  Directory directory,
+) async {
+  final content = await directory.pubspecOverrides.readAsString();
+  // Pubspec.parse requires the "name" field to be present, even though
+  // pubspec_overrides don't have one. So we inject a fake one.
+  final pubspec = Pubspec.parse('''
+name: tmp
+$content
+''');
+
+  return pubspec.dependencyOverrides;
 }
 
 /// Try parsing the package config of the given directory.

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -158,8 +158,7 @@ class SocketCustomLintServerToClientChannel {
   ///
   /// Will throw if the process fails to start.
   Future<Process?> _startProcess() async {
-    final tempDirectory =
-        _tempDirectory = await _workspace.createPluginHostDirectory();
+    final tempDirectory = _tempDirectory = await _workspace.resolvePluginHost();
     _writeEntrypoint(_workspace.uniquePluginNames, tempDirectory);
 
     return _asyncRetry(retryCount: 5, () async {

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -766,9 +766,9 @@ publish_to: 'none'
 
   /// First attempts at creating the plugin host locally. And if it fails,
   /// it will fallback to resolving packages using "pub get".
-  Future<Directory> resolvePluginHost() async {
-    final tempDir = Directory.systemTemp.createTempSync('custom_lint_client');
-
+  Future<void> resolvePluginHost(
+    Directory tempDir,
+  ) async {
     final pubspecContent = computePubspec();
     final pubspecOverride = computePubspecOverride();
 
@@ -778,17 +778,9 @@ publish_to: 'none'
     }
 
     try {
-      try {
-        await resolvePackageConfigOffline(tempDir);
-      } on PackageVersionConflictException {
-        await runPubGet(tempDir);
-      }
-
-      return tempDir;
-    } catch (_) {
-      // If failed, delete the temporary directory.
-      tempDir.deleteSync(recursive: true);
-      rethrow;
+      await resolvePackageConfigOffline(tempDir);
+    } on PackageVersionConflictException {
+      await runPubGet(tempDir);
     }
   }
 

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -906,6 +906,7 @@ class CustomLintProject {
     required this.directory,
     required this.packageConfig,
     required this.pubspec,
+    required this.pubspecOverrides,
   });
 
   /// Decode a [CustomLintProject] from a directory.
@@ -924,6 +925,7 @@ class CustomLintProject {
         errorStackTrace: stack,
       );
     });
+    final pubspecOverrides = await tryParsePubspecOverrides(directory);
     final projectPackageConfig = await parsePackageConfig(directory)
         // ignore: avoid_types_on_closure_parameters
         .catchError((Object err, StackTrace stack) {
@@ -967,6 +969,7 @@ class CustomLintProject {
       directory: directory,
       packageConfig: projectPackageConfig,
       pubspec: projectPubspec,
+      pubspecOverrides: pubspecOverrides,
     );
   }
 
@@ -975,6 +978,9 @@ class CustomLintProject {
 
   /// The pubspec.yaml at the moment of parsing.
   final Pubspec pubspec;
+
+  /// The pubspec.yaml at the moment of parsing.
+  final Map<String, Dependency>? pubspecOverrides;
 
   /// The folder of the project being analyzed.
   final Directory directory;

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -779,7 +779,7 @@ publish_to: 'none'
 
     try {
       await resolvePackageConfigOffline(tempDir);
-    } on PackageVersionConflictException {
+    } catch (_) {
       await runPubGet(tempDir);
     }
   }
@@ -809,6 +809,7 @@ publish_to: 'none'
       ['pub', 'get'],
       stdoutEncoding: utf8,
       stderrEncoding: utf8,
+      workingDirectory: tempDir.path,
     );
     if (result.exitCode != 0) {
       throw Exception(

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -135,11 +135,18 @@ String _buildDependencyConstraint(
   }
 }
 
+/// A type of version conflict
 sealed class ConflictKind {
+  /// A conflict between two dependencies from different packages in the same workspace.
   factory ConflictKind.dependency(String packageName) = _DependencyConflict;
+
+  /// A conflict between two dependencies from the same package in the same workspace.
   factory ConflictKind.environment(String packageName) = _EnvironmentConflict;
 
+  /// The human readable name of the conflict type.
   String get kindDisplayString;
+
+  /// The value of the conflict.
   String get value;
 }
 
@@ -167,6 +174,7 @@ class _DependencyConflict implements ConflictKind {
   final String packageName;
 }
 
+/// Information related to a dependency and the project it is used in.
 class DependencyConstraintMeta {
   DependencyConstraintMeta._(
     this.dependencyDisplayString,
@@ -180,6 +188,7 @@ class DependencyConstraintMeta {
           ),
         );
 
+  /// Construct a [DependencyConstraintMeta] from a [VersionConstraint].
   DependencyConstraintMeta.fromVersionConstraint(
     VersionConstraint constraint,
     CustomLintProject project, {
@@ -190,6 +199,7 @@ class DependencyConstraintMeta {
           workingDirectory: workingDirectory,
         );
 
+  /// Construct a [DependencyConstraintMeta] from a [Dependency].
   DependencyConstraintMeta.fromDependency(
     Dependency dependency,
     CustomLintProject project, {
@@ -202,7 +212,11 @@ class DependencyConstraintMeta {
 
   /// Either a [VersionConstraint] or a [Dependency].
   final String dependencyDisplayString;
+
+  /// The name of the project which uses the dependency.
   final String projectName;
+
+  /// The path to the project which uses the dependency.
   final String projectPath;
 }
 
@@ -210,12 +224,10 @@ extension on Dependency {
   String getDisplayString() {
     final that = this;
     return switch (that) {
-      // TODO show hosted
       HostedDependency() when that.version == VersionConstraint.any => 'any',
       HostedDependency() => '"${that.version}"',
       PathDependency() => '"${that.path}"',
       SdkDependency() => 'sdk: ${that.sdk}',
-      // TODO show ref/path
       GitDependency() => 'git: ${that.url}',
       _ => throw ArgumentError.value(
           runtimeType,
@@ -239,7 +251,10 @@ class IncompatibleDependencyConstraintsException implements Exception {
           'Must have at least 2 items',
         );
 
+  /// The type of conflict.
   final ConflictKind kind;
+
+  /// The conflicting dependencies.
   final List<DependencyConstraintMeta> conflictingDependencies;
 
   @override

--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -30,6 +30,7 @@ dev_dependencies:
   ansi_styles: ^0.3.2+1
   benchmark_harness: ^2.2.0
   build_runner: ^2.3.2
+  file: ^7.0.0
   freezed: ^2.3.2
   json_serializable: ^6.5.4
   test: ^1.20.2

--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/invertase/dart_custom_lint
 issue_tracker: https://github.com/invertase/dart_custom_lint/issues
 
 environment:
-  sdk: ">=2.19.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   analyzer: ^5.7.0

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -230,7 +230,7 @@ void main() {
           extraPackageConfig: {'dep': workspace.dir('dep').uri},
         );
 
-        final app2 = createLintUsage(
+        createLintUsage(
           // Add the second project inside the first one, such that
           // analyzing the first project analyzes both projects
           parent: app,
@@ -256,23 +256,11 @@ void main() {
             '''
 The request analysis.setContextRoots failed with the following error:
 RequestErrorCode.PLUGIN_ERROR
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+Exception: Failed to run "pub get" in the client project:
+Resolving dependencies...
 
-Package dep:
-- Hosted with version constraint: any
-  Resolved with ${workspace.dir('dep').path}/
-  Used by plugin "test_lint" at "../test_lint" in the project "test_app" at "."
-- Hosted with version constraint: any
-  Resolved with ${workspace.dir('dep2').path}/
-  Used by plugin "test_lint" at "../test_lint" in the project "test_app2" at "test_app2"
-
-$conflictExplanation
-You could run the following commands to try fixing this:
-
-cd ${app.path}
-dart pub upgrade dep
-cd ${app2.path}
-dart pub upgrade dep
+Because every version of test_lint from path depends on dep any which doesn't exist (could not find package dep at https://pub.dev), test_lint from path is forbidden.
+So, because test_app depends on test_lint from path, version solving failed.
 ''',
           ),
         );

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -260,7 +260,7 @@ Exception: Failed to run "pub get" in the client project:
 Resolving dependencies...
 
 Because every version of test_lint from path depends on dep any which doesn't exist (could not find package dep at https://pub.dev), test_lint from path is forbidden.
-So, because test_app depends on test_lint from path, version solving failed.
+So, because custom_lint_client depends on test_lint from path, version solving failed.
 ''',
           ),
         );

--- a/packages/custom_lint/test/src/workspace_test.dart
+++ b/packages/custom_lint/test/src/workspace_test.dart
@@ -588,7 +588,7 @@ void main() {
   });
 
   group(CustomLintWorkspace, () {
-    group('generatePuspecOverrides', () {
+    group('computePuspecOverrides', () {
       test('Do not generate a pubspec_overrides if none specified', () async {
         final workingDir = await createSimpleWorkspace([
           Pubspec(

--- a/packages/custom_lint/test/src/workspace_test.dart
+++ b/packages/custom_lint/test/src/workspace_test.dart
@@ -2476,81 +2476,81 @@ dependency_overrides:
       test(
           'should create a package_config.json with no package duplicates if a dependency is used by multiple plugins',
           () async {
-        // final workspace =
-        //     await createSimpleWorkspace(withPackageConfig: false, [
-        //   Pubspec(
-        //     'dep',
-        //     dependencies: {
-        //       'custom_lint_builder': HostedDependency(),
-        //       'transitive': HostedDependency(),
-        //     },
-        //   ),
-        //   'transitive',
-        //   Pubspec(
-        //     'dep2',
-        //     dependencies: {
-        //       'custom_lint_builder': HostedDependency(),
-        //       'transitive': HostedDependency(),
-        //     },
-        //   ),
-        //   'custom_lint_builder',
-        //   Pubspec('app', devDependencies: {'dep': HostedDependency()}),
-        //   Pubspec('app2', devDependencies: {'dep2': HostedDependency()}),
-        // ]);
+        final workspace =
+            await createSimpleWorkspace(withPackageConfig: false, [
+          Pubspec(
+            'dep',
+            dependencies: {
+              'custom_lint_builder': HostedDependency(),
+              'transitive': HostedDependency(),
+            },
+          ),
+          'transitive',
+          Pubspec(
+            'dep2',
+            dependencies: {
+              'custom_lint_builder': HostedDependency(),
+              'transitive': HostedDependency(),
+            },
+          ),
+          'custom_lint_builder',
+          Pubspec('app', devDependencies: {'dep': HostedDependency()}),
+          Pubspec('app2', devDependencies: {'dep2': HostedDependency()}),
+        ]);
 
-        // enableCustomLint(workspace.dir('app'));
-        // enableCustomLint(workspace.dir('app2'));
+        enableCustomLint(workspace.dir('app'));
+        enableCustomLint(workspace.dir('app2'));
 
-        // writeSimplePackageConfig(workspace.dir('app'), {
-        //   'dep': '../dep',
-        //   'custom_lint_builder': '../custom_lint_builder',
-        //   'transitive': '../transitive',
-        // });
-        // writeSimplePackageConfig(workspace.dir('app2'), {
-        //   'dep2': '../dep2',
-        //   'custom_lint_builder': '../custom_lint_builder',
-        //   'transitive': '../transitive',
-        // });
+        writeSimplePackageConfig(workspace.dir('app'), {
+          'dep': '../dep',
+          'custom_lint_builder': '../custom_lint_builder',
+          'transitive': '../transitive',
+        });
+        writeSimplePackageConfig(workspace.dir('app2'), {
+          'dep2': '../dep2',
+          'custom_lint_builder': '../custom_lint_builder',
+          'transitive': '../transitive',
+        });
 
-        // final customLintWorkspace = await CustomLintWorkspace.fromPaths(
-        //   [workspace.path],
-        //   workingDirectory: workspace,
-        // );
+        final customLintWorkspace = await CustomLintWorkspace.fromPaths(
+          [workspace.path],
+          workingDirectory: workspace,
+        );
 
-        // final pluginHostDirectory =
-        //     await customLintWorkspace.resolvePackageConfigOffline(
-        // createTemporaryDirectory(),
-        // );
-        // final packageConfig = parsePackageConfigSync(pluginHostDirectory);
+        final pluginHostDirectory = createTemporaryDirectory();
+        await customLintWorkspace.resolvePackageConfigOffline(
+          pluginHostDirectory,
+        );
+        final packageConfig = parsePackageConfigSync(pluginHostDirectory);
 
-        // expect(packageConfig.packages, hasLength(4));
-        // expect(
-        //   packageConfig.packages.map((p) => p.name),
-        //   unorderedEquals([
-        //     'custom_lint_builder',
-        //     'dep',
-        //     'dep2',
-        //     'transitive',
-        //   ]),
-        // );
-        // expect(
-        //   packageConfig.packages
-        //       .firstWhere((p) => p.name == 'custom_lint_builder')
-        //       .root,
-        //   workspace.dir('custom_lint_builder').uri,
-        // );
-        // expect(
-        //   packageConfig.packages.firstWhere((p) => p.name == 'dep').root,
-        //   workspace.dir('dep').uri,
-        // );
-        // expect(
-        //   packageConfig.packages.firstWhere((p) => p.name == 'dep2').root,
-        //   workspace.dir('dep2').uri,
-        // );
-        // expect(
-        //   packageConfig.packages.firstWhere((p) => p.name == 'transitive').root,
-        //   workspace.dir('transitive').uri,
-        // );
+        expect(packageConfig.packages, hasLength(4));
+        expect(
+          packageConfig.packages.map((p) => p.name),
+          unorderedEquals([
+            'custom_lint_builder',
+            'dep',
+            'dep2',
+            'transitive',
+          ]),
+        );
+        expect(
+          packageConfig.packages
+              .firstWhere((p) => p.name == 'custom_lint_builder')
+              .root,
+          workspace.dir('custom_lint_builder').uri,
+        );
+        expect(
+          packageConfig.packages.firstWhere((p) => p.name == 'dep').root,
+          workspace.dir('dep').uri,
+        );
+        expect(
+          packageConfig.packages.firstWhere((p) => p.name == 'dep2').root,
+          workspace.dir('dep2').uri,
+        );
+        expect(
+          packageConfig.packages.firstWhere((p) => p.name == 'transitive').root,
+          workspace.dir('transitive').uri,
+        );
       });
 
       test(

--- a/packages/custom_lint/test/src/workspace_test.dart
+++ b/packages/custom_lint/test/src/workspace_test.dart
@@ -588,8 +588,29 @@ void main() {
 
   group(CustomLintWorkspace, () {
     group('generatePuspecOverrides', () {
-      test(
-          'Do not generate a pubspec_overrides if none specified', () async {});
+      test('Do not generate a pubspec_overrides if none specified', () async {
+        final workingDir = await createSimpleWorkspace([
+          Pubspec(
+            'plugin1',
+            dependencies: {'custom_lint_builder': HostedDependency()},
+          ),
+          Pubspec(
+            'a',
+            devDependencies: {'plugin1': HostedDependency()},
+          ),
+          Pubspec(
+            'b',
+            devDependencies: {'plugin1': HostedDependency()},
+          ),
+        ]);
+
+        final workspace = await fromContextRootsFromPaths(
+          ['a', 'b'],
+          workingDirectory: workingDir,
+        );
+
+        expect(workspace.generatePubspecOverride(), null);
+      });
 
       test('Merges dependendency_overrides', () async {
         final workingDir = await createSimpleWorkspace([

--- a/packages/custom_lint/test/src/workspace_test.dart
+++ b/packages/custom_lint/test/src/workspace_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:analyzer_plugin/protocol/protocol_generated.dart';
 import 'package:custom_lint/src/package_utils.dart';
 import 'package:custom_lint/src/workspace.dart';
+import 'package:file/memory.dart';
 import 'package:package_config/package_config.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
@@ -609,7 +610,7 @@ void main() {
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspecOverride(), null);
+        expect(workspace.computePubspecOverride(), null);
       });
 
       test('Merges dependendency_overrides', () async {
@@ -643,7 +644,7 @@ dependency_overrides:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspecOverride(), '''
+        expect(workspace.computePubspecOverride(), '''
 dependency_overrides:
   package: ">=1.1.0 <1.6.0"
 ''');
@@ -681,7 +682,7 @@ dependency_overrides:
         );
 
         expect(
-          workspace.generatePubspecOverride,
+          workspace.computePubspecOverride,
           throwsA(
             isA<IncompatibleDependencyConstraintsException>()
                 .having((e) => e.toString(), 'toString', '''
@@ -696,7 +697,7 @@ The package "package" has incompatible version constraints in the project:
       });
     });
 
-    group('generatePubspec', () {
+    group('computePubspec', () {
       test(
           'If an environment constraint is not specified in a given project, it is considered as "any"',
           () async {
@@ -724,7 +725,7 @@ The package "package" has incompatible version constraints in the project:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -766,7 +767,7 @@ dev_dependencies:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -808,7 +809,7 @@ dev_dependencies:
         );
 
         expect(
-          workspace.generatePubspec,
+          workspace.computePubspec,
           throwsA(
             isA<IncompatibleDependencyConstraintsException>()
                 .having((e) => e.toString(), 'toString', '''
@@ -859,7 +860,7 @@ The environment "sdk" has incompatible version constraints in the project:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -900,7 +901,7 @@ dev_dependencies:
         );
 
         expect(
-          workspace.generatePubspec,
+          workspace.computePubspec,
           throwsA(
             isA<IncompatibleDependencyConstraintsException>()
                 .having((e) => e.toString(), 'toString', '''
@@ -950,7 +951,7 @@ The package "plugin1" has incompatible version constraints in the project:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -992,7 +993,7 @@ dependency_overrides:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1025,7 +1026,7 @@ dependency_overrides:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1059,7 +1060,7 @@ dependency_overrides:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1094,7 +1095,7 @@ dev_dependencies:
         );
 
         expect(
-          workspace.generatePubspec,
+          workspace.computePubspec,
           throwsA(
             isA<IncompatibleDependencyConstraintsException>()
                 .having((e) => e.toString(), 'toString', '''
@@ -1134,7 +1135,7 @@ The package "plugin1" has incompatible version constraints in the project:
         );
 
         expect(
-          workspace.generatePubspec,
+          workspace.computePubspec,
           throwsA(
             isA<IncompatibleDependencyConstraintsException>()
                 .having((e) => e.toString(), 'toString', '''
@@ -1170,7 +1171,7 @@ The package "plugin1" has incompatible version constraints in the project:
         );
 
         expect(
-          workspace.generatePubspec(),
+          workspace.computePubspec(),
           '''
 name: custom_lint_client
 description: A client for custom_lint
@@ -1206,7 +1207,7 @@ dev_dependencies:
         );
 
         expect(
-          workspace.generatePubspec,
+          workspace.computePubspec,
           throwsA(
             isA<IncompatibleDependencyConstraintsException>()
                 .having((e) => e.toString(), 'toString', '''
@@ -1242,7 +1243,7 @@ The package "plugin1" has incompatible version constraints in the project:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1284,7 +1285,7 @@ dev_dependencies:
             workingDirectory: workingDir,
           );
 
-          expect(workspace.generatePubspec(), '''
+          expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1328,7 +1329,7 @@ dev_dependencies:
             workingDirectory: workingDir,
           );
 
-          expect(workspace.generatePubspec(), '''
+          expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1375,7 +1376,7 @@ dev_dependencies:
             workingDirectory: workingDir,
           );
 
-          expect(workspace.generatePubspec(), '''
+          expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1428,7 +1429,7 @@ dev_dependencies:
           );
 
           expect(
-            workspace.generatePubspec,
+            workspace.computePubspec,
             throwsA(
               isA<IncompatibleDependencyConstraintsException>()
                   .having((e) => e.toString(), 'toString', '''
@@ -1478,7 +1479,7 @@ The package "plugin1" has incompatible version constraints in the project:
           );
 
           expect(
-            workspace.generatePubspec,
+            workspace.computePubspec,
             throwsA(
               isA<IncompatibleDependencyConstraintsException>()
                   .having((e) => e.toString(), 'toString', '''
@@ -1528,7 +1529,7 @@ The package "plugin1" has incompatible version constraints in the project:
           );
 
           expect(
-            workspace.generatePubspec,
+            workspace.computePubspec,
             throwsA(
               isA<IncompatibleDependencyConstraintsException>()
                   .having((e) => e.toString(), 'toString', '''
@@ -1576,7 +1577,7 @@ The package "plugin1" has incompatible version constraints in the project:
           );
 
           expect(
-            workspace.generatePubspec,
+            workspace.computePubspec,
             throwsA(
               isA<IncompatibleDependencyConstraintsException>()
                   .having((e) => e.toString(), 'toString', '''
@@ -1624,7 +1625,7 @@ The package "plugin1" has incompatible version constraints in the project:
           );
 
           expect(
-            workspace.generatePubspec,
+            workspace.computePubspec,
             throwsA(
               isA<IncompatibleDependencyConstraintsException>()
                   .having((e) => e.toString(), 'toString', '''
@@ -1678,7 +1679,7 @@ The package "plugin1" has incompatible version constraints in the project:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1730,7 +1731,7 @@ dependency_overrides:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -1773,7 +1774,7 @@ dev_dependencies:
           workingDirectory: workingDir,
         );
 
-        expect(workspace.generatePubspec(), '''
+        expect(workspace.computePubspec(), '''
 name: custom_lint_client
 description: A client for custom_lint
 version: 0.0.1
@@ -2471,83 +2472,85 @@ dependency_overrides:
       });
     });
 
-    group('createPluginHostDirectory', () {
+    group('resolvePackageConfigOffline', () {
       test(
           'should create a package_config.json with no package duplicates if a dependency is used by multiple plugins',
           () async {
-        final workspace =
-            await createSimpleWorkspace(withPackageConfig: false, [
-          Pubspec(
-            'dep',
-            dependencies: {
-              'custom_lint_builder': HostedDependency(),
-              'transitive': HostedDependency(),
-            },
-          ),
-          'transitive',
-          Pubspec(
-            'dep2',
-            dependencies: {
-              'custom_lint_builder': HostedDependency(),
-              'transitive': HostedDependency(),
-            },
-          ),
-          'custom_lint_builder',
-          Pubspec('app', devDependencies: {'dep': HostedDependency()}),
-          Pubspec('app2', devDependencies: {'dep2': HostedDependency()}),
-        ]);
+        // final workspace =
+        //     await createSimpleWorkspace(withPackageConfig: false, [
+        //   Pubspec(
+        //     'dep',
+        //     dependencies: {
+        //       'custom_lint_builder': HostedDependency(),
+        //       'transitive': HostedDependency(),
+        //     },
+        //   ),
+        //   'transitive',
+        //   Pubspec(
+        //     'dep2',
+        //     dependencies: {
+        //       'custom_lint_builder': HostedDependency(),
+        //       'transitive': HostedDependency(),
+        //     },
+        //   ),
+        //   'custom_lint_builder',
+        //   Pubspec('app', devDependencies: {'dep': HostedDependency()}),
+        //   Pubspec('app2', devDependencies: {'dep2': HostedDependency()}),
+        // ]);
 
-        enableCustomLint(workspace.dir('app'));
-        enableCustomLint(workspace.dir('app2'));
+        // enableCustomLint(workspace.dir('app'));
+        // enableCustomLint(workspace.dir('app2'));
 
-        writeSimplePackageConfig(workspace.dir('app'), {
-          'dep': '../dep',
-          'custom_lint_builder': '../custom_lint_builder',
-          'transitive': '../transitive',
-        });
-        writeSimplePackageConfig(workspace.dir('app2'), {
-          'dep2': '../dep2',
-          'custom_lint_builder': '../custom_lint_builder',
-          'transitive': '../transitive',
-        });
+        // writeSimplePackageConfig(workspace.dir('app'), {
+        //   'dep': '../dep',
+        //   'custom_lint_builder': '../custom_lint_builder',
+        //   'transitive': '../transitive',
+        // });
+        // writeSimplePackageConfig(workspace.dir('app2'), {
+        //   'dep2': '../dep2',
+        //   'custom_lint_builder': '../custom_lint_builder',
+        //   'transitive': '../transitive',
+        // });
 
-        final customLintWorkspace = await CustomLintWorkspace.fromPaths(
-          [workspace.path],
-          workingDirectory: workspace,
-        );
+        // final customLintWorkspace = await CustomLintWorkspace.fromPaths(
+        //   [workspace.path],
+        //   workingDirectory: workspace,
+        // );
 
-        final pluginHostDirectory =
-            await customLintWorkspace.createPluginHostDirectory();
-        final packageConfig = parsePackageConfigSync(pluginHostDirectory);
+        // final pluginHostDirectory =
+        //     await customLintWorkspace.resolvePackageConfigOffline(
+        // createTemporaryDirectory(),
+        // );
+        // final packageConfig = parsePackageConfigSync(pluginHostDirectory);
 
-        expect(packageConfig.packages, hasLength(4));
-        expect(
-          packageConfig.packages.map((p) => p.name),
-          unorderedEquals([
-            'custom_lint_builder',
-            'dep',
-            'dep2',
-            'transitive',
-          ]),
-        );
-        expect(
-          packageConfig.packages
-              .firstWhere((p) => p.name == 'custom_lint_builder')
-              .root,
-          workspace.dir('custom_lint_builder').uri,
-        );
-        expect(
-          packageConfig.packages.firstWhere((p) => p.name == 'dep').root,
-          workspace.dir('dep').uri,
-        );
-        expect(
-          packageConfig.packages.firstWhere((p) => p.name == 'dep2').root,
-          workspace.dir('dep2').uri,
-        );
-        expect(
-          packageConfig.packages.firstWhere((p) => p.name == 'transitive').root,
-          workspace.dir('transitive').uri,
-        );
+        // expect(packageConfig.packages, hasLength(4));
+        // expect(
+        //   packageConfig.packages.map((p) => p.name),
+        //   unorderedEquals([
+        //     'custom_lint_builder',
+        //     'dep',
+        //     'dep2',
+        //     'transitive',
+        //   ]),
+        // );
+        // expect(
+        //   packageConfig.packages
+        //       .firstWhere((p) => p.name == 'custom_lint_builder')
+        //       .root,
+        //   workspace.dir('custom_lint_builder').uri,
+        // );
+        // expect(
+        //   packageConfig.packages.firstWhere((p) => p.name == 'dep').root,
+        //   workspace.dir('dep').uri,
+        // );
+        // expect(
+        //   packageConfig.packages.firstWhere((p) => p.name == 'dep2').root,
+        //   workspace.dir('dep2').uri,
+        // );
+        // expect(
+        //   packageConfig.packages.firstWhere((p) => p.name == 'transitive').root,
+        //   workspace.dir('transitive').uri,
+        // );
       });
 
       test(
@@ -2603,9 +2606,9 @@ dependency_overrides:
           workingDirectory: workspace,
         );
 
-        final pluginHostDirectory =
-            await customLintWorkspace.createPluginHostDirectory();
-        final packageConfig = parsePackageConfigSync(pluginHostDirectory);
+        final tempDir = createTemporaryDirectory();
+        await customLintWorkspace.resolvePackageConfigOffline(tempDir);
+        final packageConfig = parsePackageConfigSync(tempDir);
 
         expect(packageConfig.packages, hasLength(5));
         expect(
@@ -2674,10 +2677,10 @@ dependency_overrides:
           workingDirectory: workspace,
         );
 
-        expect(
-          await customLintWorkspace.createPluginHostDirectory(),
-          isA<Directory>().having((e) => e.existsSync(), 'exists()', true),
-        );
+        final tempDir = createTemporaryDirectory();
+        await customLintWorkspace.resolvePackageConfigOffline(tempDir);
+
+        expect(tempDir.packageConfig.existsSync(), true);
       });
 
       test(
@@ -2728,10 +2731,10 @@ dependency_overrides:
           workingDirectory: workspace,
         );
 
-        expect(
-          await customLintWorkspace.createPluginHostDirectory(),
-          isA<Directory>().having((e) => e.existsSync(), 'exists()', true),
-        );
+        final tempDir = createTemporaryDirectory();
+        await customLintWorkspace.resolvePackageConfigOffline(tempDir);
+
+        expect(tempDir.packageConfig.existsSync(), true);
       });
 
       test(
@@ -2788,7 +2791,9 @@ dependency_overrides:
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           completes,
         );
       });
@@ -2855,8 +2860,11 @@ dependency_overrides:
           workingDirectory: workspace,
         );
 
+        final fs = MemoryFileSystem.test();
+        final dir = fs.directory(workspace.path)..createSync(recursive: true);
+
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(dir),
           completes,
         );
       });
@@ -2926,15 +2934,16 @@ dependency_overrides:
           (project) => project.pubspec.name == 'app2',
         );
 
+        final tempDir = createTemporaryDirectory();
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(tempDir),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Package transitive_dep:
 - Hosted with version constraint: ^1.0.0
@@ -2956,6 +2965,8 @@ dart pub upgrade transitive_dep
             ),
           ),
         );
+
+        expect(tempDir.packageConfig.existsSync(), isFalse);
       });
 
       test(
@@ -3016,14 +3027,16 @@ dart pub upgrade transitive_dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Package transitive_dep:
 - Hosted with version constraint: ^1.0.0
@@ -3132,14 +3145,16 @@ dart pub upgrade transitive_dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - Hosted with version constraint: 1.0.0
@@ -3230,14 +3245,16 @@ dart pub upgrade dep second_dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - Hosted with version constraint: ^1.0.0
@@ -3316,14 +3333,16 @@ dart pub upgrade dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - Hosted with version constraint: ^1.0.0
@@ -3397,14 +3416,16 @@ dart pub upgrade dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - Hosted with version constraint: 1.0.0
@@ -3483,14 +3504,16 @@ dart pub upgrade dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - Hosted with version constraint: 1.0.1
@@ -3568,14 +3591,16 @@ flutter pub upgrade dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - From git url ssh://git@github.com/rrousselGit/freezed.git
@@ -3654,14 +3679,16 @@ dart pub upgrade dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - From git url ssh://git@github.com/rrousselGit/freezed.git path packages/freezed
@@ -3740,14 +3767,16 @@ dart pub upgrade dep
         );
 
         await expectLater(
-          customLintWorkspace.createPluginHostDirectory(),
+          customLintWorkspace.resolvePackageConfigOffline(
+            createTemporaryDirectory(),
+          ),
           throwsA(
-            isA<PackageVersionConflictError>().having(
+            isA<PackageVersionConflictException>().having(
               (error) => error.toString(),
               'toString()',
               equals(
                 '''
-PackageVersionConflictError – Some dependencies with conflicting versions were identified:
+PackageVersionConflictException – Some dependencies with conflicting versions were identified:
 
 Plugin dep:
 - From git url ssh://git@github.com/rrousselGit/freezed.git ref 123

--- a/packages/custom_lint/test/src/workspace_test.dart
+++ b/packages/custom_lint/test/src/workspace_test.dart
@@ -582,10 +582,46 @@ void main() {
       });
 
       test(
-        'If a dependency is used with version numbers, '
-        'use a version range compatible with all packages',
-        () {},
-      );
+          'If a dependency is used with version numbers, '
+          'use a version range compatible with all packages', () async {
+        final workingDir = await createSimpleWorkspace([
+          Pubspec(
+            'plugin1',
+            dependencies: {'custom_lint_builder': HostedDependency()},
+          ),
+          Pubspec(
+            'a',
+            devDependencies: {
+              'plugin1': HostedDependency(
+                version: VersionConstraint.parse('>=1.0.0 <1.5.0'),
+              ),
+            },
+          ),
+          Pubspec(
+            'b',
+            devDependencies: {
+              'plugin1': HostedDependency(
+                version: VersionConstraint.parse('^1.3.0'),
+              ),
+            },
+          ),
+        ]);
+
+        final workspace = await fromContextRootsFromPaths(
+          ['a', 'b'],
+          workingDirectory: workingDir,
+        );
+
+        expect(workspace.generatePubspec(), '''
+name: custom_lint_client
+description: A client for custom_lint
+version: 0.0.1
+publish_to: 'none'
+
+dev_dependencies:
+  plugin1: ">=1.3.0 <1.5.0"
+''');
+      });
 
       test('Throws if no valid version range is found', () {});
 
@@ -645,12 +681,24 @@ void main() {
           ),
           Pubspec(
             'a',
-            dependencies: {'dep': HostedDependency()},
-            devDependencies: {
-              'plugin1': HostedDependency(),
-              'dev_dep': HostedDependency(),
+            dependencies: {
+              'dep': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
             },
-            dependencyOverrides: {'override': HostedDependency()},
+            devDependencies: {
+              'plugin1': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
+              'dev_dep': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
+            },
+            dependencyOverrides: {
+              'override': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
+            },
           ),
         ]);
 
@@ -666,10 +714,10 @@ version: 0.0.1
 publish_to: 'none'
 
 dev_dependencies:
-  plugin1: # TODO
+  plugin1: "^1.0.0"
 
 dependency_overrides:
-  override: # TODO
+  override: "^1.0.0"
 ''');
       });
 
@@ -688,13 +736,21 @@ dependency_overrides:
           Pubspec(
             'a',
             devDependencies: {
-              'plugin1': HostedDependency(),
-              'plugin2': HostedDependency(),
+              'plugin1': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
+              'plugin2': HostedDependency(
+                version: VersionConstraint.parse('^1.2.0'),
+              ),
             },
           ),
           Pubspec(
             'b',
-            devDependencies: {'plugin1': HostedDependency()},
+            devDependencies: {
+              'plugin1': HostedDependency(
+                version: VersionConstraint.parse('^1.0.0'),
+              ),
+            },
           ),
         ]);
 
@@ -710,8 +766,8 @@ version: 0.0.1
 publish_to: 'none'
 
 dev_dependencies:
-  plugin1: # TODO
-  plugin2: # TODO
+  plugin1: ">=1.0.0 <2.0.0"
+  plugin2: "^1.2.0"
 ''');
       });
 


### PR DESCRIPTION
- [-] also run "pub get" if project in the workspace is missing a package_config.json
  We currently rely on the package_config to detect
  - where the dependencies are in the workspace
  - if flutter is used or not
- [x] use "flutter pub get" instead of "dart pub get" when the plugin depends on flutter
- [x] Add tests for remote resolution
