### PR TITLE
Sort lints by severity before anything else

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Sort lints by severity in the command line (thanks to @kuhnroyal)
+
 ## 0.5.3 - 2023-08-29
 
 - The command line now supports ignoring warnings/infos with `--no-fatal-warnings`/`--no-fatal-infos` (thanks to @yamarkz)

--- a/packages/custom_lint/lib/custom_lint.dart
+++ b/packages/custom_lint/lib/custom_lint.dart
@@ -144,8 +144,13 @@ void _renderLints(
 }) {
   var errors = lints.expand((lint) => lint.errors);
 
-  // Sort errors by file, line, column, code, message
+  // Sort errors by severity, file, line, column, code, message
   errors = errors.sorted((a, b) {
+    final severityCompare = -AnalysisErrorSeverity.VALUES
+        .indexOf(a.severity)
+        .compareTo(AnalysisErrorSeverity.VALUES.indexOf(b.severity));
+    if (severityCompare != 0) return severityCompare;
+
     final fileCompare = _relativeFilePath(a.location.file, workingDirectory)
         .compareTo(_relativeFilePath(b.location.file, workingDirectory));
     if (fileCompare != 0) return fileCompare;

--- a/packages/custom_lint/test/cli_test.dart
+++ b/packages/custom_lint/test/cli_test.dart
@@ -304,6 +304,7 @@ Bad state: fail
     final plugin = createPlugin(
       name: 'test_lint',
       main: '''
+import 'package:analyzer/error/error.dart';
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 
@@ -349,6 +350,21 @@ class _Lint extends DartLintRule {
       0,
       1,
     );
+    reporter.reportErrorForOffset(
+      const LintCode(name: 'w', problemMessage: 'w', errorSeverity: ErrorSeverity.WARNING),
+      0,
+      1,
+    );
+    reporter.reportErrorForOffset(
+      const LintCode(name: 'e', problemMessage: 'e', errorSeverity: ErrorSeverity.ERROR),
+      0,
+      1,
+    );
+    reporter.reportErrorForOffset(
+      const LintCode(name: 's', problemMessage: 's', errorSeverity: ErrorSeverity.ERROR),
+      1,
+      2,
+    );
   }
 }
 ''',
@@ -359,6 +375,10 @@ class _Lint extends DartLintRule {
         'lib/main.dart': '''
 void main() {
   print('hello world');
+}''',
+        'lib/other.dart': '''
+void other() {
+  print('hello other world');
 }''',
       },
       plugins: {'test_lint': plugin.uri},
@@ -380,11 +400,22 @@ void main() {
           completion(
             predicate((value) {
               expect(value, '''
+  lib/main.dart:1:1 • e • e • ERROR
+  lib/main.dart:1:2 • s • s • ERROR
+  lib/other.dart:1:1 • e • e • ERROR
+  lib/other.dart:1:2 • s • s • ERROR
+  lib/main.dart:1:1 • w • w • WARNING
+  lib/other.dart:1:1 • w • w • WARNING
   lib/main.dart:1:1 • z • z • INFO
   lib/main.dart:2:1 • y • y • INFO
   lib/main.dart:2:2 • a • a • INFO
   lib/main.dart:2:2 • x • x • INFO
   lib/main.dart:2:2 • x2 • x2 • INFO
+  lib/other.dart:1:1 • z • z • INFO
+  lib/other.dart:2:1 • y • y • INFO
+  lib/other.dart:2:2 • a • a • INFO
+  lib/other.dart:2:2 • x • x • INFO
+  lib/other.dart:2:2 • x2 • x2 • INFO
 ''');
               return true;
             }),


### PR DESCRIPTION
This is in line with the behavior of `dart analyze`.