### PR TITLE
Extract output format to a class structure and add CLI parameter

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,4 +1,5 @@
-## UNRELEASED
+## Unreleased patch
+
 - Support JSON output format via CLI parameter `--format json|default` (thanks to @kuhnroyal)
 
 ## 0.5.4 - 2023-10-20

--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+- Support JSON output format via CLI parameter `--format json|default` (thanks to @kuhnroyal)
+
 ## 0.5.4 - 2023-10-20
 
 - Sort lints by severity in the command line (thanks to @kuhnroyal)

--- a/packages/custom_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/bin/custom_lint.dart
@@ -16,6 +16,19 @@ Future<void> entrypoint([List<String> args = const []]) async {
       help: 'Treat warning level issues as fatal',
       defaultsTo: true,
     )
+    ..addOption(
+      'format',
+      valueHelp: 'value',
+      help: 'Specifies the format to display lints.',
+      defaultsTo: 'default',
+      allowed: ['default'],
+      allowedHelp: {
+        'default':
+            'The default output format. This format is intended to be user '
+                'consumable.\nThe format is not specified and can change '
+                'between releases.',
+      },
+    )
     ..addFlag(
       'watch',
       help: "Watches plugins' sources and perform a hot-reload on change",
@@ -39,12 +52,14 @@ Future<void> entrypoint([List<String> args = const []]) async {
   final watchMode = result['watch'] as bool;
   final fatalInfos = result['fatal-infos'] as bool;
   final fatalWarnings = result['fatal-warnings'] as bool;
+  final format = result['format'] as String;
 
   await customLint(
     workingDirectory: Directory.current,
     watchMode: watchMode,
     fatalInfos: fatalInfos,
     fatalWarnings: fatalWarnings,
+    format: format,
   );
 }
 

--- a/packages/custom_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/bin/custom_lint.dart
@@ -16,19 +16,6 @@ Future<void> entrypoint([List<String> args = const []]) async {
       help: 'Treat warning level issues as fatal',
       defaultsTo: true,
     )
-    ..addOption(
-      'format',
-      valueHelp: 'value',
-      help: 'Specifies the format to display lints.',
-      defaultsTo: 'default',
-      allowed: ['default'],
-      allowedHelp: {
-        'default':
-            'The default output format. This format is intended to be user '
-                'consumable.\nThe format is not specified and can change '
-                'between releases.',
-      },
-    )
     ..addFlag(
       'watch',
       help: "Watches plugins' sources and perform a hot-reload on change",
@@ -52,14 +39,12 @@ Future<void> entrypoint([List<String> args = const []]) async {
   final watchMode = result['watch'] as bool;
   final fatalInfos = result['fatal-infos'] as bool;
   final fatalWarnings = result['fatal-warnings'] as bool;
-  final format = result['format'] as String;
 
   await customLint(
     workingDirectory: Directory.current,
     watchMode: watchMode,
     fatalInfos: fatalInfos,
     fatalWarnings: fatalWarnings,
-    format: format,
   );
 }
 

--- a/packages/custom_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/bin/custom_lint.dart
@@ -16,6 +16,23 @@ Future<void> entrypoint([List<String> args = const []]) async {
       help: 'Treat warning level issues as fatal',
       defaultsTo: true,
     )
+    ..addOption(
+      'format',
+      valueHelp: 'value',
+      help: 'Specifies the format to display lints.',
+      defaultsTo: 'default',
+      allowed: [
+        'default',
+        'json',
+      ],
+      allowedHelp: {
+        'default':
+            'The default output format. This format is intended to be user '
+                'consumable.\nThe format is not specified and can change '
+                'between releases.',
+        'json': 'A machine readable output in a JSON format.',
+      },
+    )
     ..addFlag(
       'watch',
       help: "Watches plugins' sources and perform a hot-reload on change",
@@ -39,12 +56,14 @@ Future<void> entrypoint([List<String> args = const []]) async {
   final watchMode = result['watch'] as bool;
   final fatalInfos = result['fatal-infos'] as bool;
   final fatalWarnings = result['fatal-warnings'] as bool;
+  final format = result['format'] as String;
 
   await customLint(
     workingDirectory: Directory.current,
     watchMode: watchMode,
     fatalInfos: fatalInfos,
     fatalWarnings: fatalWarnings,
+    format: format,
   );
 }
 

--- a/packages/custom_lint/bin/custom_lint.dart
+++ b/packages/custom_lint/bin/custom_lint.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:custom_lint/custom_lint.dart';
+import 'package:custom_lint/src/output/output_format.dart';
 
 Future<void> entrypoint([List<String> args = const []]) async {
   final parser = ArgParser()
@@ -22,8 +23,8 @@ Future<void> entrypoint([List<String> args = const []]) async {
       help: 'Specifies the format to display lints.',
       defaultsTo: 'default',
       allowed: [
-        'default',
-        'json',
+        OutputFormatEnum.plain.name,
+        OutputFormatEnum.json.name,
       ],
       allowedHelp: {
         'default':
@@ -63,7 +64,7 @@ Future<void> entrypoint([List<String> args = const []]) async {
     watchMode: watchMode,
     fatalInfos: fatalInfos,
     fatalWarnings: fatalWarnings,
-    format: format,
+    format: OutputFormatEnum.fromName(format),
   );
 }
 

--- a/packages/custom_lint/lib/custom_lint.dart
+++ b/packages/custom_lint/lib/custom_lint.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:cli_util/cli_logging.dart';
 
 import 'src/cli_logger.dart';
+import 'src/output/output_format.dart';
 import 'src/output/render_lints.dart';
 import 'src/plugin_delegate.dart';
 import 'src/runner.dart';
@@ -38,7 +39,7 @@ Future<void> customLint({
   required Directory workingDirectory,
   bool fatalInfos = true,
   bool fatalWarnings = true,
-  String format = 'default',
+  OutputFormatEnum format = OutputFormatEnum.plain,
 }) async {
   // Reset the code
   exitCode = 0;
@@ -66,7 +67,7 @@ Future<void> _runServer(
   required Directory workingDirectory,
   required bool fatalInfos,
   required bool fatalWarnings,
-  required String format,
+  required OutputFormatEnum format,
 }) async {
   final customLintServer = await CustomLintServer.start(
     sendPort: channel.receivePort.sendPort,
@@ -134,7 +135,7 @@ Future<void> _runPlugins(
   required Directory workingDirectory,
   required bool fatalInfos,
   required bool fatalWarnings,
-  required String format,
+  required OutputFormatEnum format,
 }) async {
   final lints = await runner.getLints(reload: reload);
 
@@ -155,7 +156,7 @@ Future<void> _startWatchMode(
   required Directory workingDirectory,
   required bool fatalInfos,
   required bool fatalWarnings,
-  required String format,
+  required OutputFormatEnum format,
 }) async {
   if (stdin.hasTerminal) {
     stdin

--- a/packages/custom_lint/lib/src/output/default_output_format.dart
+++ b/packages/custom_lint/lib/src/output/default_output_format.dart
@@ -1,8 +1,8 @@
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:cli_util/cli_logging.dart';
 
-import 'render_lints.dart';
 import 'output_format.dart';
+import 'render_lints.dart';
 
 /// The default output format.
 class DefaultOutputFormat implements OutputFormat {

--- a/packages/custom_lint/lib/src/output/default_output_format.dart
+++ b/packages/custom_lint/lib/src/output/default_output_format.dart
@@ -13,7 +13,6 @@ class DefaultOutputFormat implements OutputFormat {
   void render({
     required Iterable<AnalysisError> errors,
     required Logger log,
-    required Progress progress,
   }) {
     if (errors.isEmpty) {
       log.stdout('No issues found!');

--- a/packages/custom_lint/lib/src/output/default_output_format.dart
+++ b/packages/custom_lint/lib/src/output/default_output_format.dart
@@ -1,0 +1,35 @@
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:cli_util/cli_logging.dart';
+
+import 'render_lints.dart';
+import 'output_format.dart';
+
+/// The default output format.
+class DefaultOutputFormat implements OutputFormat {
+  @override
+  bool get sorted => true;
+
+  @override
+  void render({
+    required Iterable<AnalysisError> errors,
+    required Logger log,
+    required Progress progress,
+  }) {
+    if (errors.isEmpty) {
+      log.stdout('No issues found!');
+      return;
+    }
+
+    for (final error in errors) {
+      log.stdout(
+        '  ${error.location.relativePath}:${error.location.startLine}:${error.location.startColumn}'
+        ' • ${error.message} • ${error.code} • ${error.severity.name}',
+      );
+    }
+
+    // Display a summary separated from the lints
+    log.stdout('');
+    final errorCount = errors.length;
+    log.stdout('$errorCount issue${errorCount > 1 ? 's' : ''} found.');
+  }
+}

--- a/packages/custom_lint/lib/src/output/default_output_format.dart
+++ b/packages/custom_lint/lib/src/output/default_output_format.dart
@@ -7,9 +7,6 @@ import 'output_format.dart';
 /// The default output format.
 class DefaultOutputFormat implements OutputFormat {
   @override
-  bool get sorted => true;
-
-  @override
   void render({
     required Iterable<AnalysisError> errors,
     required Logger log,

--- a/packages/custom_lint/lib/src/output/json_output_format.dart
+++ b/packages/custom_lint/lib/src/output/json_output_format.dart
@@ -15,54 +15,25 @@ class JsonOutputFormat implements OutputFormat {
     required Iterable<AnalysisError> errors,
     required Logger log,
   }) {
-    Map<String, dynamic> location(
-      String filePath,
-      Map<String, dynamic> range,
-    ) =>
-        {
-          'file': filePath,
-          'range': range,
-        };
-
-    Map<String, dynamic> position(
-      int? offset,
-      int? line,
-      int? column,
-    ) =>
-        {
-          'offset': offset,
-          'line': line,
-          'column': column,
-        };
-
-    Map<String, dynamic> range(
-      Map<String, dynamic> start,
-      Map<String, dynamic> end,
-    ) =>
-        {
-          'start': start,
-          'end': end,
-        };
-
-    final diagnostics = <Map<String, dynamic>>[];
+    final diagnostics = <Map<String, Object?>>[];
     for (final error in errors) {
-      final contextMessages = <Map<String, dynamic>>[];
+      final contextMessages = <Map<String, Object?>>[];
       if (error.contextMessages != null) {
         for (final contextMessage in error.contextMessages!) {
           final startOffset = contextMessage.location.offset;
           contextMessages.add({
-            'location': location(
-              contextMessage.location.file,
-              range(
-                position(
-                  startOffset,
-                  contextMessage.location.startLine,
-                  contextMessage.location.startColumn,
+            'location': _location(
+              file: contextMessage.location.file,
+              range: _range(
+                start: _position(
+                  offset: startOffset,
+                  line: contextMessage.location.startLine,
+                  column: contextMessage.location.startColumn,
                 ),
-                position(
-                  startOffset + contextMessage.location.length,
-                  contextMessage.location.endLine,
-                  contextMessage.location.endColumn,
+                end: _position(
+                  offset: startOffset + contextMessage.location.length,
+                  line: contextMessage.location.endLine,
+                  column: contextMessage.location.endColumn,
                 ),
               ),
             ),
@@ -75,18 +46,18 @@ class JsonOutputFormat implements OutputFormat {
         'code': error.code,
         'severity': error.severity,
         'type': error.type,
-        'location': location(
-          error.location.file,
-          range(
-            position(
-              startOffset,
-              error.location.startLine,
-              error.location.startColumn,
+        'location': _location(
+          file: error.location.file,
+          range: _range(
+            start: _position(
+              offset: startOffset,
+              line: error.location.startLine,
+              column: error.location.startColumn,
             ),
-            position(
-              startOffset + error.location.length,
-              error.location.endLine,
-              error.location.endColumn,
+            end: _position(
+              offset: startOffset + error.location.length,
+              line: error.location.endLine,
+              column: error.location.endColumn,
             ),
           ),
         ),
@@ -102,5 +73,37 @@ class JsonOutputFormat implements OutputFormat {
         'diagnostics': diagnostics,
       }),
     );
+  }
+
+  Map<String, Object?> _location({
+    required String file,
+    required Map<String, Object?> range,
+  }) {
+    return {
+      'file': file,
+      'range': range,
+    };
+  }
+
+  Map<String, Object?> _position({
+    int? offset,
+    int? line,
+    int? column,
+  }) {
+    return {
+      'offset': offset,
+      'line': line,
+      'column': column,
+    };
+  }
+
+  Map<String, Object?> _range({
+    required Map<String, Object?> start,
+    required Map<String, Object?> end,
+  }) {
+    return {
+      'start': start,
+      'end': end,
+    };
   }
 }

--- a/packages/custom_lint/lib/src/output/json_output_format.dart
+++ b/packages/custom_lint/lib/src/output/json_output_format.dart
@@ -4,7 +4,6 @@ import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:cli_util/cli_logging.dart';
 
 import 'output_format.dart';
-import 'render_lints.dart';
 
 /// The JSON output format.
 ///
@@ -47,10 +46,10 @@ class JsonOutputFormat implements OutputFormat {
 
     final diagnostics = <Map<String, dynamic>>[];
     for (final error in errors) {
-      final contextMessages = [];
+      final contextMessages = <Map<String, dynamic>>[];
       if (error.contextMessages != null) {
         for (final contextMessage in error.contextMessages!) {
-          var startOffset = contextMessage.location.offset;
+          final startOffset = contextMessage.location.offset;
           contextMessages.add({
             'location': location(
               contextMessage.location.file,
@@ -97,9 +96,11 @@ class JsonOutputFormat implements OutputFormat {
         if (error.url != null) 'documentation': error.url,
       });
     }
-    log.stdout(json.encode({
-      'version': 1,
-      'diagnostics': diagnostics,
-    }));
+    log.stdout(
+      json.encode({
+        'version': 1,
+        'diagnostics': diagnostics,
+      }),
+    );
   }
 }

--- a/packages/custom_lint/lib/src/output/json_output_format.dart
+++ b/packages/custom_lint/lib/src/output/json_output_format.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:cli_util/cli_logging.dart';
+
+import 'output_format.dart';
+import 'render_lints.dart';
+
+/// The JSON output format.
+///
+/// Code is an adaption of the original Dart SDK JSON format.
+/// See: https://github.com/dart-lang/sdk/blob/main/pkg/dartdev/lib/src/commands/analyze.dart
+class JsonOutputFormat implements OutputFormat {
+  @override
+  void render({
+    required Iterable<AnalysisError> errors,
+    required Logger log,
+  }) {
+    Map<String, dynamic> location(
+      String filePath,
+      Map<String, dynamic> range,
+    ) =>
+        {
+          'file': filePath,
+          'range': range,
+        };
+
+    Map<String, dynamic> position(
+      int? offset,
+      int? line,
+      int? column,
+    ) =>
+        {
+          'offset': offset,
+          'line': line,
+          'column': column,
+        };
+
+    Map<String, dynamic> range(
+      Map<String, dynamic> start,
+      Map<String, dynamic> end,
+    ) =>
+        {
+          'start': start,
+          'end': end,
+        };
+
+    final diagnostics = <Map<String, dynamic>>[];
+    for (final error in errors) {
+      final contextMessages = [];
+      if (error.contextMessages != null) {
+        for (final contextMessage in error.contextMessages!) {
+          var startOffset = contextMessage.location.offset;
+          contextMessages.add({
+            'location': location(
+              contextMessage.location.file,
+              range(
+                position(
+                  startOffset,
+                  contextMessage.location.startLine,
+                  contextMessage.location.startColumn,
+                ),
+                position(
+                  startOffset + contextMessage.location.length,
+                  contextMessage.location.endLine,
+                  contextMessage.location.endColumn,
+                ),
+              ),
+            ),
+            'message': contextMessage.message,
+          });
+        }
+      }
+      final startOffset = error.location.offset;
+      diagnostics.add({
+        'code': error.code,
+        'severity': error.severity,
+        'type': error.type,
+        'location': location(
+          error.location.file,
+          range(
+            position(
+              startOffset,
+              error.location.startLine,
+              error.location.startColumn,
+            ),
+            position(
+              startOffset + error.location.length,
+              error.location.endLine,
+              error.location.endColumn,
+            ),
+          ),
+        ),
+        'problemMessage': error.message,
+        if (error.correction != null) 'correctionMessage': error.correction,
+        if (contextMessages.isNotEmpty) 'contextMessages': contextMessages,
+        if (error.url != null) 'documentation': error.url,
+      });
+    }
+    log.stdout(json.encode({
+      'version': 1,
+      'diagnostics': diagnostics,
+    }));
+  }
+}

--- a/packages/custom_lint/lib/src/output/output_format.dart
+++ b/packages/custom_lint/lib/src/output/output_format.dart
@@ -3,9 +3,6 @@ import 'package:cli_util/cli_logging.dart';
 
 /// An abstract class for outputting lints
 abstract class OutputFormat {
-  /// Whether the lints should be sorted before being rendered.
-  bool get sorted => false;
-
   /// Renders lints according to the format and flags.
   void render({
     required Iterable<AnalysisError> errors,

--- a/packages/custom_lint/lib/src/output/output_format.dart
+++ b/packages/custom_lint/lib/src/output/output_format.dart
@@ -1,0 +1,15 @@
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:cli_util/cli_logging.dart';
+
+/// An abstract class for outputting lints
+abstract class OutputFormat {
+  /// Whether the lints should be sorted before being rendered.
+  bool get sorted => false;
+
+  /// Renders lints according to the format and flags.
+  void render({
+    required Iterable<AnalysisError> errors,
+    required Logger log,
+    required Progress progress,
+  });
+}

--- a/packages/custom_lint/lib/src/output/output_format.dart
+++ b/packages/custom_lint/lib/src/output/output_format.dart
@@ -10,6 +10,5 @@ abstract class OutputFormat {
   void render({
     required Iterable<AnalysisError> errors,
     required Logger log,
-    required Progress progress,
   });
 }

--- a/packages/custom_lint/lib/src/output/output_format.dart
+++ b/packages/custom_lint/lib/src/output/output_format.dart
@@ -1,6 +1,30 @@
 import 'package:analyzer_plugin/protocol/protocol_common.dart';
 import 'package:cli_util/cli_logging.dart';
 
+/// An enum for the output format.
+enum OutputFormatEnum {
+  /// The default output format.
+  plain._('default'),
+
+  /// Dart SDK like JSON output format.
+  json._('json');
+
+  const OutputFormatEnum._(this.name);
+
+  /// The name of the format.
+  final String name;
+
+  /// Returns the [OutputFormatEnum] for the given [name].
+  static OutputFormatEnum fromName(String name) {
+    for (final format in OutputFormatEnum.values) {
+      if (format.name == name) {
+        return format;
+      }
+    }
+    return plain;
+  }
+}
+
 /// An abstract class for outputting lints
 abstract class OutputFormat {
   /// Renders lints according to the format and flags.

--- a/packages/custom_lint/lib/src/output/render_lints.dart
+++ b/packages/custom_lint/lib/src/output/render_lints.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+import 'package:analyzer_plugin/protocol/protocol_common.dart';
+import 'package:analyzer_plugin/protocol/protocol_generated.dart';
+import 'package:cli_util/cli_logging.dart';
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as p;
+
+import 'default_output_format.dart';
+import 'output_format.dart';
+
+/// Renders lints according to the given format and flags.
+void renderLints(
+  List<AnalysisErrorsParams> lints, {
+  required Logger log,
+  required Progress progress,
+  required Directory workingDirectory,
+  required bool fatalInfos,
+  required bool fatalWarnings,
+  required String format,
+}) {
+  final OutputFormat outputFormat;
+  switch (format) {
+    case 'default':
+    default:
+      outputFormat = DefaultOutputFormat();
+  }
+
+  var errors = lints.expand((lint) => lint.errors);
+
+  var fatal = false;
+  for (final error in errors) {
+    error.location.relativePath = p.relative(
+      error.location.file,
+      from: workingDirectory.absolute.path,
+    );
+    fatal = fatal ||
+        error.severity == AnalysisErrorSeverity.ERROR ||
+        (fatalWarnings && error.severity == AnalysisErrorSeverity.WARNING) ||
+        (fatalInfos && error.severity == AnalysisErrorSeverity.INFO);
+  }
+
+  if (outputFormat.sorted) {
+    // Sort errors by severity, file, line, column, code, message
+    // if the output format requires it
+    errors = errors.sorted((a, b) {
+      final severityCompare = -AnalysisErrorSeverity.VALUES
+          .indexOf(a.severity)
+          .compareTo(AnalysisErrorSeverity.VALUES.indexOf(b.severity));
+      if (severityCompare != 0) return severityCompare;
+
+      final fileCompare =
+          a.location.relativePath.compareTo(b.location.relativePath);
+      if (fileCompare != 0) return fileCompare;
+
+      final lineCompare = a.location.startLine.compareTo(b.location.startLine);
+      if (lineCompare != 0) return lineCompare;
+
+      final columnCompare =
+          a.location.startColumn.compareTo(b.location.startColumn);
+      if (columnCompare != 0) return columnCompare;
+
+      final codeCompare = a.code.compareTo(b.code);
+      if (codeCompare != 0) return codeCompare;
+
+      return a.message.compareTo(b.message);
+    });
+  }
+
+  // Finish progress and display duration (only when ANSI is supported)
+  progress.finish(showTiming: true);
+
+  // Separate progress from results
+  log.stdout('');
+
+  outputFormat.render(
+    errors: errors,
+    log: log,
+    progress: progress,
+  );
+
+  if (fatal) {
+    exitCode = 1;
+    return;
+  }
+}
+
+final _locationRelativePath = Expando('locationRelativePath');
+
+/// A helper extension to set/get
+/// the working directory relative path of a [Location].
+extension LocationRelativePath on Location {
+  /// The working directory relative path of this [Location].
+  String get relativePath => _locationRelativePath[this]! as String;
+
+  set relativePath(String path) => _locationRelativePath[this] = path;
+}

--- a/packages/custom_lint/lib/src/output/render_lints.dart
+++ b/packages/custom_lint/lib/src/output/render_lints.dart
@@ -75,7 +75,6 @@ void renderLints(
   outputFormat.render(
     errors: errors,
     log: log,
-    progress: progress,
   );
 
   if (fatal) {

--- a/packages/custom_lint/lib/src/output/render_lints.dart
+++ b/packages/custom_lint/lib/src/output/render_lints.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 
 import 'default_output_format.dart';
+import 'json_output_format.dart';
 import 'output_format.dart';
 
 /// Renders lints according to the given format and flags.
@@ -20,6 +21,9 @@ void renderLints(
 }) {
   final OutputFormat outputFormat;
   switch (format) {
+    case 'json':
+      outputFormat = JsonOutputFormat();
+      break;
     case 'default':
     default:
       outputFormat = DefaultOutputFormat();
@@ -39,32 +43,30 @@ void renderLints(
         (fatalInfos && error.severity == AnalysisErrorSeverity.INFO);
   }
 
-  if (outputFormat.sorted) {
-    // Sort errors by severity, file, line, column, code, message
-    // if the output format requires it
-    errors = errors.sorted((a, b) {
-      final severityCompare = -AnalysisErrorSeverity.VALUES
-          .indexOf(a.severity)
-          .compareTo(AnalysisErrorSeverity.VALUES.indexOf(b.severity));
-      if (severityCompare != 0) return severityCompare;
+  // Sort errors by severity, file, line, column, code, message
+  // if the output format requires it
+  errors = errors.sorted((a, b) {
+    final severityCompare = -AnalysisErrorSeverity.VALUES
+        .indexOf(a.severity)
+        .compareTo(AnalysisErrorSeverity.VALUES.indexOf(b.severity));
+    if (severityCompare != 0) return severityCompare;
 
-      final fileCompare =
-          a.location.relativePath.compareTo(b.location.relativePath);
-      if (fileCompare != 0) return fileCompare;
+    final fileCompare =
+        a.location.relativePath.compareTo(b.location.relativePath);
+    if (fileCompare != 0) return fileCompare;
 
-      final lineCompare = a.location.startLine.compareTo(b.location.startLine);
-      if (lineCompare != 0) return lineCompare;
+    final lineCompare = a.location.startLine.compareTo(b.location.startLine);
+    if (lineCompare != 0) return lineCompare;
 
-      final columnCompare =
-          a.location.startColumn.compareTo(b.location.startColumn);
-      if (columnCompare != 0) return columnCompare;
+    final columnCompare =
+        a.location.startColumn.compareTo(b.location.startColumn);
+    if (columnCompare != 0) return columnCompare;
 
-      final codeCompare = a.code.compareTo(b.code);
-      if (codeCompare != 0) return codeCompare;
+    final codeCompare = a.code.compareTo(b.code);
+    if (codeCompare != 0) return codeCompare;
 
-      return a.message.compareTo(b.message);
-    });
-  }
+    return a.message.compareTo(b.message);
+  });
 
   // Finish progress and display duration (only when ANSI is supported)
   progress.finish(showTiming: true);

--- a/packages/custom_lint/lib/src/output/render_lints.dart
+++ b/packages/custom_lint/lib/src/output/render_lints.dart
@@ -17,14 +17,14 @@ void renderLints(
   required Directory workingDirectory,
   required bool fatalInfos,
   required bool fatalWarnings,
-  required String format,
+  required OutputFormatEnum format,
 }) {
   final OutputFormat outputFormat;
   switch (format) {
-    case 'json':
+    case OutputFormatEnum.json:
       outputFormat = JsonOutputFormat();
       break;
-    case 'default':
+    case OutputFormatEnum.plain:
     default:
       outputFormat = DefaultOutputFormat();
   }

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -2,6 +2,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:custom_lint/src/output/output_format.dart';
 import 'package:custom_lint/src/package_utils.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
@@ -147,7 +148,7 @@ No issues found!
       },
     );
 
-    for (final format in ['default', 'json']) {
+    for (final format in OutputFormatEnum.values.map((e) => e.name)) {
       test(
         'found lints format: $format',
         () async {

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:custom_lint/src/package_utils.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
@@ -190,10 +189,10 @@ No issues found!
                             'file': '$dir/lib/another.dart',
                             'range': {
                               'start': {'offset': 5, 'line': 1, 'column': 6},
-                              'end': {'offset': 9, 'line': 1, 'column': 10}
-                            }
+                              'end': {'offset': 9, 'line': 1, 'column': 10},
+                            },
                           },
-                          'problemMessage': 'Oy'
+                          'problemMessage': 'Oy',
                         },
                         {
                           'code': 'oy',
@@ -203,12 +202,12 @@ No issues found!
                             'file': '$dir/lib/main.dart',
                             'range': {
                               'start': {'offset': 5, 'line': 1, 'column': 6},
-                              'end': {'offset': 7, 'line': 1, 'column': 8}
-                            }
+                              'end': {'offset': 7, 'line': 1, 'column': 8},
+                            },
                           },
-                          'problemMessage': 'Oy'
+                          'problemMessage': 'Oy',
                         }
-                      ]
+                      ],
                     })}\n');
           } else {
             expect(process.stdout, '''

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:custom_lint/src/package_utils.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
@@ -147,28 +148,70 @@ No issues found!
       },
     );
 
-    test(
-      'found lints',
-      () async {
-        final plugin = createPlugin(name: 'test_lint', main: oyPluginSource);
+    for (final format in ['default', 'json']) {
+      test(
+        'found lints format: $format',
+        () async {
+          final plugin = createPlugin(name: 'test_lint', main: oyPluginSource);
 
-        final app = createLintUsage(
-          name: 'test_app',
-          source: {
-            'lib/main.dart': 'void fn() {}',
-            'lib/another.dart': 'void fail() {}',
-          },
-          plugins: {'test_lint': plugin.uri},
-        );
+          final app = createLintUsage(
+            name: 'test_app',
+            source: {
+              'lib/main.dart': 'void fn() {}',
+              'lib/another.dart': 'void fail() {}',
+            },
+            plugins: {'test_lint': plugin.uri},
+          );
 
-        final process = await Process.run(
-          'dart',
-          [customLintBinPath],
-          workingDirectory: app.path,
-        );
+          final process = await Process.run(
+            'dart',
+            [
+              customLintBinPath,
+              '--format',
+              format,
+            ],
+            workingDirectory: app.path,
+          );
 
-        expect(trimDependencyOverridesWarning(process.stderr), isEmpty);
-        expect(process.stdout, '''
+          expect(trimDependencyOverridesWarning(process.stderr), isEmpty);
+
+          if (format == 'json') {
+            final dir = Directory(app.path).resolveSymbolicLinksSync();
+            expect(
+                process.stdout,
+                'Analyzing...\n\n${jsonEncode({
+                      'version': 1,
+                      'diagnostics': [
+                        {
+                          'code': 'oy',
+                          'severity': 'INFO',
+                          'type': 'LINT',
+                          'location': {
+                            'file': '$dir/lib/another.dart',
+                            'range': {
+                              'start': {'offset': 5, 'line': 1, 'column': 6},
+                              'end': {'offset': 9, 'line': 1, 'column': 10}
+                            }
+                          },
+                          'problemMessage': 'Oy'
+                        },
+                        {
+                          'code': 'oy',
+                          'severity': 'INFO',
+                          'type': 'LINT',
+                          'location': {
+                            'file': '$dir/lib/main.dart',
+                            'range': {
+                              'start': {'offset': 5, 'line': 1, 'column': 6},
+                              'end': {'offset': 7, 'line': 1, 'column': 8}
+                            }
+                          },
+                          'problemMessage': 'Oy'
+                        }
+                      ]
+                    })}\n');
+          } else {
+            expect(process.stdout, '''
 Analyzing...
 
   lib/another.dart:1:6 • Oy • oy • INFO
@@ -176,9 +219,11 @@ Analyzing...
 
 2 issues found.
 ''');
-        expect(process.exitCode, 1);
-      },
-    );
+          }
+          expect(process.exitCode, 1);
+        },
+      );
+    }
 
     test(
       'missing package_config.json',

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -177,39 +177,38 @@ No issues found!
 
           if (format == 'json') {
             final dir = Directory(app.path).resolveSymbolicLinksSync();
-            expect(
-                process.stdout,
-                'Analyzing...\n\n${jsonEncode({
-                      'version': 1,
-                      'diagnostics': [
-                        {
-                          'code': 'oy',
-                          'severity': 'INFO',
-                          'type': 'LINT',
-                          'location': {
-                            'file': '$dir/lib/another.dart',
-                            'range': {
-                              'start': {'offset': 5, 'line': 1, 'column': 6},
-                              'end': {'offset': 9, 'line': 1, 'column': 10},
-                            },
-                          },
-                          'problemMessage': 'Oy',
-                        },
-                        {
-                          'code': 'oy',
-                          'severity': 'INFO',
-                          'type': 'LINT',
-                          'location': {
-                            'file': '$dir/lib/main.dart',
-                            'range': {
-                              'start': {'offset': 5, 'line': 1, 'column': 6},
-                              'end': {'offset': 7, 'line': 1, 'column': 8},
-                            },
-                          },
-                          'problemMessage': 'Oy',
-                        }
-                      ],
-                    })}\n');
+            final json = jsonEncode({
+              'version': 1,
+              'diagnostics': [
+                {
+                  'code': 'oy',
+                  'severity': 'INFO',
+                  'type': 'LINT',
+                  'location': {
+                    'file': '$dir/lib/another.dart',
+                    'range': {
+                      'start': {'offset': 5, 'line': 1, 'column': 6},
+                      'end': {'offset': 9, 'line': 1, 'column': 10},
+                    },
+                  },
+                  'problemMessage': 'Oy',
+                },
+                {
+                  'code': 'oy',
+                  'severity': 'INFO',
+                  'type': 'LINT',
+                  'location': {
+                    'file': '$dir/lib/main.dart',
+                    'range': {
+                      'start': {'offset': 5, 'line': 1, 'column': 6},
+                      'end': {'offset': 7, 'line': 1, 'column': 8},
+                    },
+                  },
+                  'problemMessage': 'Oy',
+                }
+              ],
+            });
+            expect(process.stdout, 'Analyzing...\n\n$json\n');
           } else {
             expect(process.stdout, '''
 Analyzing...

--- a/packages/custom_lint/test/cli_test.dart
+++ b/packages/custom_lint/test/cli_test.dart
@@ -31,6 +31,98 @@ Pattern progressMessage({required bool supportsAnsiEscapes}) {
   return r'Analyzing\.\.\..*';
 }
 
+String jsonLints(String dir) {
+  return jsonEncode({
+    'version': 1,
+    'diagnostics': [
+      {
+        'code': 'hello_world',
+        'severity': 'INFO',
+        'type': 'LINT',
+        'location': {
+          'file': '$dir/lib/another.dart',
+          'range': {
+            'start': {
+              'offset': 5,
+              'line': 1,
+              'column': 6,
+            },
+            'end': {
+              'offset': 9,
+              'line': 1,
+              'column': 10,
+            },
+          },
+        },
+        'problemMessage': 'Hello world',
+      },
+      {
+        'code': 'oy',
+        'severity': 'INFO',
+        'type': 'LINT',
+        'location': {
+          'file': '$dir/lib/another.dart',
+          'range': {
+            'start': {
+              'offset': 5,
+              'line': 1,
+              'column': 6,
+            },
+            'end': {
+              'offset': 9,
+              'line': 1,
+              'column': 10,
+            },
+          },
+        },
+        'problemMessage': 'Oy',
+      },
+      {
+        'code': 'hello_world',
+        'severity': 'INFO',
+        'type': 'LINT',
+        'location': {
+          'file': '$dir/lib/main.dart',
+          'range': {
+            'start': {
+              'offset': 5,
+              'line': 1,
+              'column': 6,
+            },
+            'end': {
+              'offset': 7,
+              'line': 1,
+              'column': 8,
+            },
+          },
+        },
+        'problemMessage': 'Hello world',
+      },
+      {
+        'code': 'oy',
+        'severity': 'INFO',
+        'type': 'LINT',
+        'location': {
+          'file': '$dir/lib/main.dart',
+          'range': {
+            'start': {
+              'offset': 5,
+              'line': 1,
+              'column': 6,
+            },
+            'end': {
+              'offset': 7,
+              'line': 1,
+              'column': 8,
+            },
+          },
+        },
+        'problemMessage': 'Oy',
+      }
+    ],
+  });
+}
+
 void main() {
   // Run 2 tests, one with ANSI escapes and one without
   // One test has no lints, the other has some, this should be enough.
@@ -103,97 +195,7 @@ void main() {
                         supportsAnsiEscapes: ansi,
                       ),
                     ),
-                    format == 'json'
-                        ? endsWith('${jsonEncode({
-                                'version': 1,
-                                'diagnostics': [
-                                  {
-                                    'code': 'hello_world',
-                                    'severity': 'INFO',
-                                    'type': 'LINT',
-                                    'location': {
-                                      'file': '$dir/lib/another.dart',
-                                      'range': {
-                                        'start': {
-                                          'offset': 5,
-                                          'line': 1,
-                                          'column': 6,
-                                        },
-                                        'end': {
-                                          'offset': 9,
-                                          'line': 1,
-                                          'column': 10,
-                                        },
-                                      },
-                                    },
-                                    'problemMessage': 'Hello world',
-                                  },
-                                  {
-                                    'code': 'oy',
-                                    'severity': 'INFO',
-                                    'type': 'LINT',
-                                    'location': {
-                                      'file': '$dir/lib/another.dart',
-                                      'range': {
-                                        'start': {
-                                          'offset': 5,
-                                          'line': 1,
-                                          'column': 6,
-                                        },
-                                        'end': {
-                                          'offset': 9,
-                                          'line': 1,
-                                          'column': 10,
-                                        },
-                                      },
-                                    },
-                                    'problemMessage': 'Oy',
-                                  },
-                                  {
-                                    'code': 'hello_world',
-                                    'severity': 'INFO',
-                                    'type': 'LINT',
-                                    'location': {
-                                      'file': '$dir/lib/main.dart',
-                                      'range': {
-                                        'start': {
-                                          'offset': 5,
-                                          'line': 1,
-                                          'column': 6,
-                                        },
-                                        'end': {
-                                          'offset': 7,
-                                          'line': 1,
-                                          'column': 8,
-                                        },
-                                      },
-                                    },
-                                    'problemMessage': 'Hello world',
-                                  },
-                                  {
-                                    'code': 'oy',
-                                    'severity': 'INFO',
-                                    'type': 'LINT',
-                                    'location': {
-                                      'file': '$dir/lib/main.dart',
-                                      'range': {
-                                        'start': {
-                                          'offset': 5,
-                                          'line': 1,
-                                          'column': 6,
-                                        },
-                                        'end': {
-                                          'offset': 7,
-                                          'line': 1,
-                                          'column': 8,
-                                        },
-                                      },
-                                    },
-                                    'problemMessage': 'Oy',
-                                  }
-                                ],
-                              })}\n')
-                        : endsWith('''
+                    format == 'json' ? endsWith('$jsonLints\n') : endsWith('''
   lib/another.dart:1:6 • Hello world • hello_world • INFO
   lib/another.dart:1:6 • Oy • oy • INFO
   lib/main.dart:1:6 • Hello world • hello_world • INFO

--- a/packages/custom_lint/test/cli_test.dart
+++ b/packages/custom_lint/test/cli_test.dart
@@ -195,7 +195,9 @@ void main() {
                         supportsAnsiEscapes: ansi,
                       ),
                     ),
-                    format == 'json' ? endsWith('$jsonLints\n') : endsWith('''
+                    format == 'json'
+                        ? endsWith('${jsonLints(dir)}\n')
+                        : endsWith('''
   lib/another.dart:1:6 • Hello world • hello_world • INFO
   lib/another.dart:1:6 • Oy • oy • INFO
   lib/main.dart:1:6 • Hello world • hello_world • INFO

--- a/packages/custom_lint/test/cli_test.dart
+++ b/packages/custom_lint/test/cli_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/error/error.dart';
+import 'package:custom_lint/src/output/output_format.dart';
 import 'package:test/test.dart';
 
 import '../bin/custom_lint.dart' as cli;
@@ -34,7 +35,7 @@ void main() {
   // Run 2 tests, one with ANSI escapes and one without
   // One test has no lints, the other has some, this should be enough.
   for (final ansi in [true, false]) {
-    for (final format in ['default', 'json']) {
+    for (final format in OutputFormatEnum.values.map((e) => e.name)) {
       group('With ANSI: $ansi and format: $format', () {
         test('exits with 0 when no lint and no error are found', () async {
           final plugin =

--- a/packages/custom_lint/test/cli_test.dart
+++ b/packages/custom_lint/test/cli_test.dart
@@ -91,9 +91,7 @@ void main() {
             (out, err) async {
               await cli.entrypoint(['--format', format]);
 
-              final dir = IOOverrides.current!
-                  .getCurrentDirectory()
-                  .resolveSymbolicLinksSync();
+              final dir = IOOverrides.current!.getCurrentDirectory().path;
               expect(err, emitsDone);
               expect(
                 out.join(),
@@ -118,16 +116,16 @@ void main() {
                                         'start': {
                                           'offset': 5,
                                           'line': 1,
-                                          'column': 6
+                                          'column': 6,
                                         },
                                         'end': {
                                           'offset': 9,
                                           'line': 1,
-                                          'column': 10
-                                        }
-                                      }
+                                          'column': 10,
+                                        },
+                                      },
                                     },
-                                    'problemMessage': 'Hello world'
+                                    'problemMessage': 'Hello world',
                                   },
                                   {
                                     'code': 'oy',
@@ -139,16 +137,16 @@ void main() {
                                         'start': {
                                           'offset': 5,
                                           'line': 1,
-                                          'column': 6
+                                          'column': 6,
                                         },
                                         'end': {
                                           'offset': 9,
                                           'line': 1,
-                                          'column': 10
-                                        }
-                                      }
+                                          'column': 10,
+                                        },
+                                      },
                                     },
-                                    'problemMessage': 'Oy'
+                                    'problemMessage': 'Oy',
                                   },
                                   {
                                     'code': 'hello_world',
@@ -160,16 +158,16 @@ void main() {
                                         'start': {
                                           'offset': 5,
                                           'line': 1,
-                                          'column': 6
+                                          'column': 6,
                                         },
                                         'end': {
                                           'offset': 7,
                                           'line': 1,
-                                          'column': 8
-                                        }
-                                      }
+                                          'column': 8,
+                                        },
+                                      },
                                     },
-                                    'problemMessage': 'Hello world'
+                                    'problemMessage': 'Hello world',
                                   },
                                   {
                                     'code': 'oy',
@@ -181,18 +179,18 @@ void main() {
                                         'start': {
                                           'offset': 5,
                                           'line': 1,
-                                          'column': 6
+                                          'column': 6,
                                         },
                                         'end': {
                                           'offset': 7,
                                           'line': 1,
-                                          'column': 8
-                                        }
-                                      }
+                                          'column': 8,
+                                        },
+                                      },
                                     },
-                                    'problemMessage': 'Oy'
+                                    'problemMessage': 'Oy',
                                   }
-                                ]
+                                ],
                               })}\n')
                         : endsWith('''
   lib/another.dart:1:6 • Hello world • hello_world • INFO


### PR DESCRIPTION
* add CLI format parameter with currently only one option (default)
* implement default format as class
* refactor rendering and optimise relative path & fatal handling
* only sort lints if the output format requires this (future JSON format does not need this)

I intend to create another PR with the Dart JSON output as follow up, but splitting this in a separate PR for easier review.
No test changes, output stays the same for now.