### PR TITLE
- Added `encodePrioritizedSourceChanges`, to enable writing a `List<PrioritizedSourceChanges>` to a file

### DIFF
--- a/packages/custom_lint_core/CHANGELOG.md
+++ b/packages/custom_lint_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased patch
+
+- Added `encodePrioritizedSourceChanges`, to enable writing a `List<PrioritizedSourceChanges>` to a file
+- `matcherNormalizedPrioritizedSourceChangeSnapshot` now optionally
+  takes a `String source`. This enables saving to the disk the expected
+  result.
+
 ## 0.5.11 - 2024-01-27
 
 - `custom_lint` upgraded to `0.5.11`

--- a/packages/custom_lint_core/test/assist_test.dart
+++ b/packages/custom_lint_core/test/assist_test.dart
@@ -29,11 +29,12 @@ void main() {
     final assist = MyAssist('MyAssist');
     final assist2 = MyAssist('Another');
 
-    final file = writeToTemporaryFile('''
+    const fileSource = '''
 void main() {
   print('Hello world');
 }
-''');
+''';
+    final file = writeToTemporaryFile(fileSource);
     final result = await resolveFile2(path: file.path);
     result as ResolvedUnitResult;
 
@@ -42,20 +43,36 @@ void main() {
 
     expect(
       await changes,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot.json',
+        source: fileSource,
+      ),
     );
     expect(
       await changes,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot2.json',
+          source: fileSource,
+        ),
+      ),
     );
 
     expect(
       await changes2,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot.json',
+          source: fileSource,
+        ),
+      ),
     );
     expect(
       await changes2,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot2.json',
+        source: fileSource,
+      ),
     );
   });
 
@@ -107,31 +124,48 @@ void main() {
     final assist = MyAssist('MyAssist');
     final assist2 = MyAssist('Another');
 
-    final file = writeToTemporaryFile('''
+    const fileSource = '''
 void main() {
   print('Hello world');
 }
-''');
+''';
+    final file = writeToTemporaryFile(fileSource);
 
     final changes = assist.testAnalyzeAndRun(file, SourceRange.EMPTY);
     final changes2 = assist2.testAnalyzeAndRun(file, SourceRange.EMPTY);
 
     expect(
       await changes,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot.json',
+        source: fileSource,
+      ),
     );
     expect(
       await changes,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot2.json',
+          source: fileSource,
+        ),
+      ),
     );
 
     expect(
       await changes2,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot.json',
+          source: fileSource,
+        ),
+      ),
     );
     expect(
       await changes2,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot2.json',
+        source: fileSource,
+      ),
     );
   });
 }
@@ -149,12 +183,12 @@ class MyAssist extends DartAssist {
     SourceRange target,
   ) {
     context.registry.addMethodInvocation((node) {
-      final changebuilder = reporter.createChangeBuilder(
+      final changeBuilder = reporter.createChangeBuilder(
         message: name,
         priority: 1,
       );
 
-      changebuilder.addGenericFileEdit((builder) {
+      changeBuilder.addGenericFileEdit((builder) {
         builder.addSimpleInsertion(node.offset, 'Hello');
       });
     });
@@ -175,12 +209,12 @@ class MyCustomAssist extends DartAssist {
     SourceRange target,
   ) {
     context.registry.addMethodInvocation((node) {
-      final changebuilder = reporter.createChangeBuilder(
+      final changeBuilder = reporter.createChangeBuilder(
         message: name,
         priority: 1,
       );
 
-      changebuilder.addGenericFileEdit(
+      changeBuilder.addGenericFileEdit(
         (builder) {
           builder.addSimpleInsertion(node.offset, 'Custom 2023');
         },

--- a/packages/custom_lint_core/test/fix_test.dart
+++ b/packages/custom_lint_core/test/fix_test.dart
@@ -16,11 +16,12 @@ void main() {
     final fix = MyFix('MyAssist');
     final fix2 = MyFix('Another');
 
-    final file = writeToTemporaryFile('''
+    const fileSource = '''
 void main() {
   print('Hello world');
 }
-''');
+''';
+    final file = writeToTemporaryFile(fileSource);
     final result = await resolveFile2(path: file.path);
     result as ResolvedUnitResult;
 
@@ -31,42 +32,67 @@ void main() {
 
     expect(
       await changes,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot.json',
+        source: fileSource,
+      ),
     );
     expect(
       await changes,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot2.json',
+          source: fileSource,
+        ),
+      ),
     );
 
     expect(
       await changes2,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot.json',
+          source: fileSource,
+        ),
+      ),
     );
     expect(
       await changes2,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot2.json',
+        source: fileSource,
+      ),
     );
   });
 
   test('Fix.testAnalyzeRun', () async {
     final fix = MyFix('MyAssist');
 
-    final file = writeToTemporaryFile('''
+    const fileSource = '''
 void main() {
   print('Hello world');
 }
-''');
+''';
+    final file = writeToTemporaryFile(fileSource);
     final errors = await const MyLintRule().testAnalyzeAndRun(file);
 
     final changes = fix.testAnalyzeAndRun(file, errors.single, errors);
 
     expect(
       await changes,
-      matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot.json'),
+      matcherNormalizedPrioritizedSourceChangeSnapshot(
+        'snapshot.json',
+        source: fileSource,
+      ),
     );
     expect(
       await changes,
-      isNot(matcherNormalizedPrioritizedSourceChangeSnapshot('snapshot2.json')),
+      isNot(
+        matcherNormalizedPrioritizedSourceChangeSnapshot(
+          'snapshot2.json',
+          source: fileSource,
+        ),
+      ),
     );
   });
 }
@@ -85,12 +111,12 @@ class MyFix extends DartFix {
     List<AnalysisError> others,
   ) {
     context.registry.addMethodInvocation((node) {
-      final changebuilder = reporter.createChangeBuilder(
+      final changeBuilder = reporter.createChangeBuilder(
         message: name,
         priority: 1,
       );
 
-      changebuilder.addGenericFileEdit((builder) {
+      changeBuilder.addGenericFileEdit((builder) {
         builder.addSimpleInsertion(node.offset, 'Hello');
       });
     });

--- a/packages/custom_lint_core/test/snapshot.json
+++ b/packages/custom_lint_core/test/snapshot.json
@@ -1,1 +1,26 @@
-[{"priority":1,"change":{"message":"MyAssist","edits":[{"fileStamp":0,"edits":[{"offset":16,"length":0,"replacement":"Hello"}]}],"linkedEditGroups":[]}}]
+[
+  {
+    "result": "void main() {\n  Helloprint('Hello world');\n}\n",
+    "changes": [
+      {
+        "priority": 1,
+        "change": {
+          "message": "MyAssist",
+          "edits": [
+            {
+              "fileStamp": 0,
+              "edits": [
+                {
+                  "offset": 16,
+                  "length": 0,
+                  "replacement": "Hello"
+                }
+              ]
+            }
+          ],
+          "linkedEditGroups": []
+        }
+      }
+    ]
+  }
+]

--- a/packages/custom_lint_core/test/snapshot2.json
+++ b/packages/custom_lint_core/test/snapshot2.json
@@ -1,1 +1,26 @@
-[{"priority":1,"change":{"message":"Another","edits":[{"fileStamp":0,"edits":[{"offset":16,"length":0,"replacement":"Hello"}]}],"linkedEditGroups":[]}}]
+[
+  {
+    "result": "void main() {\n  Helloprint('Hello world');\n}\n",
+    "changes": [
+      {
+        "priority": 1,
+        "change": {
+          "message": "Another",
+          "edits": [
+            {
+              "fileStamp": 0,
+              "edits": [
+                {
+                  "offset": 16,
+                  "length": 0,
+                  "replacement": "Hello"
+                }
+              ]
+            }
+          ],
+          "linkedEditGroups": []
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
- `matcherNormalizedPrioritizedSourceChangeSnapshot` now optionally
  takes a `String source`. This enables saving to the disk the expected
  result.