### PR TITLE
fix error • ambiguous_import in packages/custom_lint_core/lib/src/lint_rule.dart

### DIFF
--- a/packages/custom_lint_core/lib/src/lint_rule.dart
+++ b/packages/custom_lint_core/lib/src/lint_rule.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' show AnalysisError;
 import 'package:analyzer/error/listener.dart';
 import 'package:meta/meta.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';


### PR DESCRIPTION
fix `error • ambiguous_import`

custom_lint_core/lib/src/lintrule.dart import both:
```dart
import 'package:analyzer/error/error.dart';
//...
import '../custom_lint_core.dart';
```
Version **6.8.0** of package:analyzer [0e39ed6](https://github.com/dart-lang/sdk/commit/0e39ed67e6c37cc62703ed6ddf1e2907edacb312#diff-6ee0031397643072880fd5dc7e9f47036337973030082eb32df95f0a6bea0a5b) also exports LintCode.