### PR TITLE
Skip dependency caches path in `_findRoots`.

### DIFF
--- a/packages/custom_lint/CHANGELOG.md
+++ b/packages/custom_lint/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased patch
+
+- Fixed an error in the CLI when Flutter generates code under `.dart_tool/` or has dependencies on iOS libraries (thanks to @Kurogoma4D)
+
 ## 0.6.5 - 2024-08-15
 
 - Upgraded to analyzer ^6.6.0.

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -429,8 +429,14 @@ Iterable<String> _findRoots(String path) sync* {
       return false;
     }
     // Check if the project has a package_config.json file.
-    return File(join(file.parent.path, '.dart_tool/package_config.json'))
-        .existsSync();
+    final isChildFromCache =
+        file.path.contains('.dart_tool') || file.path.contains('.symlinks');
+    if (isChildFromCache) {
+      return File(join(file.parent.path, '.dart_tool/package_config.json'))
+          .existsSync();
+    }
+
+    return true;
   }).map((file) => file.parent.path);
 }
 

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -424,13 +424,13 @@ Iterable<String> _findRoots(String path) sync* {
   final directory = Directory(path);
 
   yield* directory.listSync(recursive: true).whereType<File>().where((file) {
-    // Skip the root of dependency caches.
-    if (file.path.contains('.dart_tool') || file.path.contains('.symlinks')) {
+    final fileName = basename(file.path);
+    if (fileName != 'pubspec.yaml' && fileName != 'analysis_options.yaml') {
       return false;
     }
-
-    final fileName = basename(file.path);
-    return fileName == 'pubspec.yaml' || fileName == 'analysis_options.yaml';
+    // Check if the project has a package_config.json file.
+    return File(join(file.parent.path, '.dart_tool/package_config.json'))
+        .existsSync();
   }).map((file) => file.parent.path);
 }
 

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -424,6 +424,11 @@ Iterable<String> _findRoots(String path) sync* {
   final directory = Directory(path);
 
   yield* directory.listSync(recursive: true).whereType<File>().where((file) {
+    // Skip the root of dependency caches.
+    if (file.path.contains('.dart_tool') || file.path.contains('.symlinks')) {
+      return false;
+    }
+
     final fileName = basename(file.path);
     return fileName == 'pubspec.yaml' || fileName == 'analysis_options.yaml';
   }).map((file) => file.parent.path);

--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -430,10 +430,9 @@ Iterable<String> _findRoots(String path) sync* {
     }
     // Check if the project has a package_config.json file.
     final isChildFromCache =
-        file.path.contains('.dart_tool') || file.path.contains('.symlinks');
+        file.uri.pathSegments.any((e) => e == '.dart_tool' || e == '.symlinks');
     if (isChildFromCache) {
-      return File(join(file.parent.path, '.dart_tool/package_config.json'))
-          .existsSync();
+      return file.parent.packageConfig.existsSync();
     }
 
     return true;

--- a/packages/custom_lint/test/cli_process_test.dart
+++ b/packages/custom_lint/test/cli_process_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:custom_lint/src/output/output_format.dart';
 import 'package:custom_lint_core/custom_lint_core.dart';
+import 'package:path/path.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
@@ -105,6 +106,47 @@ No issues found!
         'dart',
         [customLintBinPath],
         workingDirectory: dir.path,
+        stdoutEncoding: utf8,
+        stderrEncoding: utf8,
+      );
+
+      expect(trimDependencyOverridesWarning(process.stderr), isEmpty);
+      expect(process.stdout, '''
+Analyzing...
+
+No issues found!
+''');
+      expect(process.exitCode, 0);
+    });
+
+    test(
+        'running on a workspace with dependencies without a package_config.json',
+        () {
+      final app = createLintUsage(name: 'test_app');
+      const testDepsName = 'test_deps';
+      const testDepsPubSpec = '''
+name: $testDepsName
+version: 0.0.1
+''';
+      createTmpFolder(
+        {
+          'pubspec.yaml': testDepsPubSpec,
+        },
+        testDepsName,
+        parent: Directory(join(app.path, '.dart_tool')),
+      );
+      createTmpFolder(
+        {
+          join('.symlinks', 'plugins', 'pubspec.yaml'): testDepsPubSpec,
+        },
+        'ios',
+        parent: app,
+      );
+
+      final process = Process.runSync(
+        'dart',
+        [customLintBinPath],
+        workingDirectory: app.path,
         stdoutEncoding: utf8,
         stderrEncoding: utf8,
       );


### PR DESCRIPTION
Fixes #268.