### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To create a custom lint, you will need two things:
 
         // This line tells custom_lint to render a warning at the location of "node".
         // And the warning shown will use our `code` variable defined above as description.
-        reporter.reportErrorForNode(code, node);
+        reporter.atNode(node, code);
       });
     }
   }


### PR DESCRIPTION
> 'reportErrorForNode' is deprecated and shouldn't be used. Use atNode() instead.
> Try replacing the use of the deprecated member with the replacement.dart[deprecated_member_use]

Update ErrorReporter method calling at readme file