### PR TITLE
fix: using old version custom_lint on analyzer plugin

### DIFF
--- a/packages/custom_lint/pubspec.yaml
+++ b/packages/custom_lint/pubspec.yaml
@@ -1,5 +1,5 @@
 name: custom_lint
-version: 0.7.2
+version: 0.7.3
 description: Lint rules are a powerful way to improve the maintainability of a project. Custom Lint allows package authors and developers to easily write custom lint rules.
 repository: https://github.com/invertase/dart_custom_lint
 issue_tracker: https://github.com/invertase/dart_custom_lint/issues

--- a/packages/custom_lint/tools/analyzer_plugin/pubspec.yaml
+++ b/packages/custom_lint/tools/analyzer_plugin/pubspec.yaml
@@ -1,13 +1,13 @@
 name: custom_lint_analyzer_plugin_loader
 description: This pubspec determines the version of the analyzer plugin to load.
-version: 0.7.0
+version: 0.7.3
 publish_to: none
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  custom_lint: 0.7.0
+  custom_lint: 0.7.3
 
 # TODO: If you want to contribute to custom_lint, add a pubspec_overrides.yaml file
 # in this folder, containing the following:

--- a/packages/custom_lint_builder/pubspec.yaml
+++ b/packages/custom_lint_builder/pubspec.yaml
@@ -1,5 +1,5 @@
 name: custom_lint_builder
-version: 0.7.2
+version: 0.7.3
 description: A package to help writing custom linters
 repository: https://github.com/invertase/dart_custom_lint
 
@@ -12,7 +12,7 @@ dependencies:
   collection: ^1.16.0
   # Using tight constraints as custom_lint_builder communicate with each-other
   # using a specific contract
-  custom_lint: 0.7.2
+  custom_lint: 0.7.3
   # Using tight constraints as custom_lint_builder communicate with each-other
   # using a specific contract
   custom_lint_core: 0.7.1


### PR DESCRIPTION
analyzer_plugin refers to old version custom_lint because of not upgrading version on `packages/custom_lint/tools/analyzer_plugin/pubspec.yaml`.

Fixes #307