### PR TITLE
Fix custom lint for flutter 3.24.5

### DIFF
--- a/packages/custom_lint/lib/src/workspace.dart
+++ b/packages/custom_lint/lib/src/workspace.dart
@@ -750,7 +750,7 @@ publish_to: 'none'
 
   /// Run "pub get" in the client project.
   Future<void> runPubGet(Directory tempDir) async {
-    final command = isUsingFlutter ? 'flutter' : 'dart';
+    final command = Platform.resolvedExecutable;
 
     final result = await runProcess(
       command,

--- a/packages/custom_lint/test/src/workspace_test.dart
+++ b/packages/custom_lint/test/src/workspace_test.dart
@@ -950,49 +950,8 @@ dependency_overrides:
 
         expect(
           processes.removeFirst(),
-          (executable: 'dart', args: const ['pub', 'get'], runInShell: false),
-        );
-        expect(processes, isEmpty);
-      });
-
-      test('uses fluter pub get if isUsingFlutter is true',
-          timeout: const Timeout.factor(2), () async {
-        final workingDir = await createSimpleWorkspace([
-          'flutter',
-          'custom_lint_builder',
-          Pubspec(
-            'plugin1',
-            environment: {'sdk': VersionConstraint.parse('^3.0.0')},
-            dependencies: {'custom_lint_builder': HostedDependency()},
-          ),
-          Pubspec(
-            'a',
-            environment: {'sdk': VersionConstraint.parse('^3.0.0')},
-            devDependencies: {
-              'plugin1': PathDependency('../plugin1'),
-              'flutter': PathDependency('../flutter'),
-            },
-          ),
-        ]);
-
-        final processes = spyProcess();
-
-        final workspace = await fromContextRootsFromPaths(
-          ['a'],
-          workingDirectory: workingDir,
-        );
-
-        expect(processes, isEmpty);
-
-        await expectLater(
-          workspace.runPubGet(workingDir.dir('a')),
-          completes,
-        );
-
-        expect(
-          processes.removeFirst(),
           (
-            executable: 'flutter',
+            executable: Platform.resolvedExecutable,
             args: const ['pub', 'get'],
             runInShell: false,
           ),


### PR DESCRIPTION
Needed for flutter 3.24.5, is it possible to have a new release for the version 0.7.0 ex: custom_lint: 0.7.0+1 ? 

Else we will downgrade.