### PR TITLE
 feat: add support for configuration error severities in `analysis_options.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,24 @@ custom_lint:
       some_parameter: "some value"
 ```
 
+#### Overriding lint error severities
+
+You can also override the severity of lint rules in the `analysis_options.yaml` file.
+This allows you to change INFO level lints to WARNING or ERROR, or vice versa:
+
+```yaml
+custom_lint:
+  rules:
+    - my_lint_rule # enable the rule with default severity
+  errors:
+    my_lint_rule: error # Override severity to ERROR
+    another_rule: warning # Override severity to WARNING 
+    third_rule: info # Override severity to INFO
+    fourth_rule: none # Suppress the lint entirely
+```
+
+The available severity levels are: `error`, `warning`, `info`, and `none`.
+
 ### Obtaining the list of lints in the CI
 
 Unfortunately, running `dart analyze` does not pick up our newly defined lints.

--- a/packages/custom_lint_builder/lib/src/client.dart
+++ b/packages/custom_lint_builder/lib/src/client.dart
@@ -995,6 +995,7 @@ class _ClientAnalyzerPlugin extends analyzer_plugin.ServerPlugin {
               allAnalysisErrors,
               lineInfo: resolver.lineInfo,
               options: analysisContext.getAnalysisOptionsForFile(file),
+              configSeverities: configs.configs.errors,
             ),
           ).toNotification(),
         ),

--- a/packages/custom_lint_core/test/configs_test.dart
+++ b/packages/custom_lint_core/test/configs_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io' as io;
 
+import 'package:analyzer/error/error.dart';
 import 'package:analyzer/file_system/file_system.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
 import 'package:custom_lint_core/custom_lint_core.dart';
@@ -115,6 +116,7 @@ custom_lint:
   test('Empty config', () {
     expect(CustomLintConfigs.empty.enableAllLintRules, null);
     expect(CustomLintConfigs.empty.rules, isEmpty);
+    expect(CustomLintConfigs.empty.errors, isEmpty);
   });
 
   group('parse', () {
@@ -184,6 +186,25 @@ custom_lint:
 
       expect(
         () => configs.rules['b'] = const LintOptions.empty(enabled: true),
+        throwsUnsupportedError,
+      );
+    });
+
+    test('has an immutable map of errors', () {
+      final analysisOptions = createAnalysisOptions('''
+custom_lint:
+  errors:
+    a: error
+''');
+      final configs = CustomLintConfigs.parse(analysisOptions, packageConfig);
+
+      expect(
+        configs.errors,
+        {'a': ErrorSeverity.ERROR},
+      );
+
+      expect(
+        () => configs.errors['a'] = ErrorSeverity.INFO,
         throwsUnsupportedError,
       );
     });
@@ -338,6 +359,68 @@ foo:
       });
     });
 
+    test('Parses error severities from configs', () {
+      final analysisOptions = createAnalysisOptions('''
+custom_lint:
+  errors:
+    rule_name_1: error
+    rule_name_2: warning
+    rule_name_3: info
+    rule_name_4: none
+''');
+      final configs = CustomLintConfigs.parse(analysisOptions, packageConfig);
+
+      expect(configs.errors, {
+        'rule_name_1': ErrorSeverity.ERROR,
+        'rule_name_2': ErrorSeverity.WARNING,
+        'rule_name_3': ErrorSeverity.INFO,
+        'rule_name_4': ErrorSeverity.NONE,
+      });
+    });
+
+    test('Handles unknown error severity values', () {
+      final analysisOptions = createAnalysisOptions('''
+custom_lint:
+  errors:
+    rule_name_1: invalid_severity
+''');
+      expect(
+        () => CustomLintConfigs.parse(analysisOptions, packageConfig),
+        throwsA(
+          isArgumentError.having(
+            (e) => e.message,
+            'message',
+            'Provided error severity: invalid_severity specified for key: rule_name_1 is not valid. '
+                'Valid error severities are: none, info, warning, error',
+          ),
+        ),
+      );
+    });
+
+    test('Merges error severities from included config file', () {
+      final includedFile = createAnalysisOptions('''
+custom_lint:
+  errors:
+    rule_name_1: error
+    rule_name_2: warning
+''');
+
+      final analysisOptions = createAnalysisOptions('''
+include: ${includedFile.path}
+custom_lint:
+  errors:
+    rule_name_2: info
+    rule_name_3: error
+''');
+      final configs = CustomLintConfigs.parse(analysisOptions, packageConfig);
+
+      expect(configs.errors, {
+        'rule_name_1': ErrorSeverity.ERROR,
+        'rule_name_2': ErrorSeverity.INFO,
+        'rule_name_3': ErrorSeverity.ERROR,
+      });
+    });
+
     group('package config', () {
       test('single package', () async {
         final dir = createDir();
@@ -353,7 +436,6 @@ foo:
 
       test('workspace', () async {
         final dir = createDir();
-        print(dir);
         final projectPath = await createTempProject(
           tempDirPath: dir.path,
           projectName: testPackageName,


### PR DESCRIPTION
Closes issue: [ISSUE-323](https://github.com/invertase/dart_custom_lint/issues/323)

Now it is possible to override error severities from analysis_options.yaml using the errors parameter inside custom_lint

You should be able to do this:
```yaml
custom_lint:
  errors:
    some_lint_with_info_severity: error
```    

All of the some_lint_with_info_severity lint's error messages will be shown as errors by the analyzer
