### PR TITLE
fix: prevent loop request analysis.updateContent when logging

### DIFF
--- a/packages/custom_lint/lib/src/v2/custom_lint_analyzer_plugin.dart
+++ b/packages/custom_lint/lib/src/v2/custom_lint_analyzer_plugin.dart
@@ -187,9 +187,18 @@ class CustomLintServer {
           return _runner.run(() async {
             final clientChannel = await _clientChannel.safeFirst;
             if (clientChannel == null) return null;
+            Request? requestRewrite;
+            if (request.method == ANALYSIS_REQUEST_UPDATE_CONTENT) {
+              final params = AnalysisUpdateContentParams.fromRequest(request);
+              params.files.removeWhere(
+                (key, value) => key.endsWith('custom_lint.log'),
+              );
+              if (params.files.isEmpty) return null;
+              requestRewrite = params.toRequest(request.id);
+            }
 
-            final response =
-                await clientChannel.sendAnalyzerPluginRequest(request);
+            final response = await clientChannel
+                .sendAnalyzerPluginRequest(requestRewrite ?? request);
             _analyzerPluginClientChannel.sendJson(response.toJson());
             return null;
           });


### PR DESCRIPTION
https://github.com/invertase/dart_custom_lint/issues/327

When throw exception plugin write log to `custom_lint.log` also send request `analysis.updateContent` to server, request will fail then throw exception again and again -> Infinity loop