### PR TITLE
fix: drop request if process not ready yet

### DIFF
--- a/packages/custom_lint/lib/src/v2/custom_lint_analyzer_plugin.dart
+++ b/packages/custom_lint/lib/src/v2/custom_lint_analyzer_plugin.dart
@@ -190,6 +190,8 @@ class CustomLintServer {
 
             final response =
                 await clientChannel.sendAnalyzerPluginRequest(request);
+            // A request was dropped, so nothing to do.
+            if (response.id.isEmpty) return null;
             _analyzerPluginClientChannel.sendJson(response.toJson());
             return null;
           });

--- a/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
+++ b/packages/custom_lint/lib/src/v2/server_to_client_channel.dart
@@ -77,10 +77,10 @@ class SocketCustomLintServerToClientChannel {
   final CustomLintServer _server;
   final PluginVersionCheckParams _version;
   final ServerSocket _serverSocket;
-  late final Future<Process?> _processFuture;
   final CustomLintWorkspace _workspace;
 
   AnalysisSetContextRootsParams _contextRoots;
+  Future<Process?>? _processFuture;
 
   late final Stream<CustomLintMessage> _messages = _channel.messages
       .map((e) => e! as Map<String, Object?>)
@@ -258,6 +258,13 @@ void main(List<String> args) async {
       ),
     );
 
+    // Drop all request if process not ready yet
+    // Because request will never got response and wait forever
+    if (request is CustomLintRequestAnalyzerPluginRequest &&
+        (_processFuture == null || await _processFuture == null)) {
+      return CustomLintResponseAnalyzerPluginResponse(Response('', 0), id: '');
+    }
+
     await _channel.sendJson(request.toJson());
 
     final response = await matchingResponse;
@@ -296,11 +303,12 @@ void main(List<String> args) async {
       _socket.then((value) => value.close()),
       _serverSocket.close(),
       _channel.close(),
-      _processFuture.then<void>(
-        (value) => value?.kill(),
-        // The process wasn't started. No need to do anything.
-        onError: (_) {},
-      ),
+      if (_processFuture != null)
+        _processFuture!.then<void>(
+          (value) => value?.kill(),
+          // The process wasn't started. No need to do anything.
+          onError: (_) {},
+        ),
     ]);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/rrousselGit/riverpod/issues/3582 https://github.com/dart-lang/sdk/issues/55281 

When `custom_lint` send request before client process started it will never got response and stuck at [analysis.setContextRoots](https://github.com/invertase/dart_custom_lint/blob/main/packages/custom_lint/lib/src/v2/server_to_client_channel.dart#L126), and block all later request.

e.g:
- Open project in VSCode with many PINNED files, custom_lint will send many request `analysis.setSubscriptions`, `analysis.setPriorityFiles`, `analysis.updateContent` BEFORE client process started
- Open project in VSCode and run Debug session immediately, custom_lint will send many request for files changed in build process BEFORE client process started
- ...