### PR TITLE
Update custom_lint_visitor analyzer dependency version to ^8.0.0

### DIFF
--- a/packages/custom_lint_visitor/pubspec.yaml
+++ b/packages/custom_lint_visitor/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: 8.1.1
+  analyzer: ^8.0.0
 
 dev_dependencies:
   build_runner: ^2.5.0


### PR DESCRIPTION
I've got another package update that depends on analyzer ^8.2.0 which conflicts with `custom_lint_visitor`. This PR updates `custom_lint_visitor` to specify `analyzer: ^8.0.0` which matches the other custom_lint packages.